### PR TITLE
Fix build error on arm hardfloat (Raspberry Pi)

### DIFF
--- a/desmume/src/utils/arm_arm/arm_jit.cpp
+++ b/desmume/src/utils/arm_arm/arm_jit.cpp
@@ -33,6 +33,7 @@ using namespace arm_gen;
 #include "MMU.h"
 #include "MMU_timing.h"
 #include "arm_jit.h"
+#include "utils/bits.h"
 #include "bios.h"
 #include "armcpu.h"
 


### PR DESCRIPTION
The "utils/bits.h" include needs to be added or else build will fail.