### PR TITLE
Selectable Multisample level.

### DIFF
--- a/desmume/src/OGLRender.cpp
+++ b/desmume/src/OGLRender.cpp
@@ -1473,6 +1473,9 @@ FragmentColor* OpenGLRenderer::GetFramebuffer()
 	return (this->willFlipAndConvertFramebufferOnGPU && this->isPBOSupported) ? this->_mappedFramebuffer : GPU->GetEngineMain()->Get3DFramebufferMain();
 }
 
+#if defined(__LIBRETRO__)
+extern int multisample_level;
+#endif
 
 GLsizei OpenGLRenderer::GetLimitedMultisampleSize() const
 {
@@ -1498,7 +1501,11 @@ GLsizei OpenGLRenderer::GetLimitedMultisampleSize() const
 	{
 		maxMultisamples = OGLMaxMultisamples_Tier4;
 	}
-	
+
+#if defined(__LIBRETRO__)
+   maxMultisamples = multisample_level;
+#endif
+
 	if (deviceMultisamples > maxMultisamples)
 	{
 		deviceMultisamples = maxMultisamples;

--- a/desmume/src/frontend/libretro/libretro.cpp
+++ b/desmume/src/frontend/libretro/libretro.cpp
@@ -77,6 +77,7 @@ static int hybrid_layout_scale = 1;
 static bool hybrid_layout_showbothscreens = true;
 static bool hybrid_cursor_always_smallscreen = true;
 static uint16_t pointer_colour = 0xFFFF;
+int multisample_level;
 
 static uint16_t *screen_buf;
 
@@ -836,10 +837,13 @@ static void check_variables(bool first_boot)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "enabled"))
-         CommonSettings.GFX3D_Renderer_Multisample = true;
-      else if (!strcmp(var.value, "disabled"))
+      if (!strcmp(var.value, "disabled"))
          CommonSettings.GFX3D_Renderer_Multisample = false;
+      else
+      {
+         CommonSettings.GFX3D_Renderer_Multisample = true;
+         multisample_level = atoi(var.value);
+      }
    }
    else
       CommonSettings.GFX3D_Renderer_Multisample = false;
@@ -1123,7 +1127,7 @@ void retro_set_environment(retro_environment_t cb)
       { "desmume_internal_resolution", "Internal resolution (restart); 256x192|512x384|768x576|1024x768|1280x960|1536x1152|1792x1344|2048x1536|2304x1728|2560x1920" },
 #ifdef HAVE_OPENGL
       { "desmume_opengl_mode", "OpenGL Rasterizer (restart); disabled|enabled" },
-      { "desmume_gfx_multisampling", "GL Multisampling; disabled|enabled" },
+      { "desmume_gfx_multisampling", "GL Multisampling (restart); disabled|2|4|8|16|32" },
       { "desmume_gfx_texture_smoothing", "GL Enable texture smoothing; disabled|enabled" },
 #endif
       { "desmume_gfx_texture_scaling", "Texture scaling (xBrz); 1|2|4" },


### PR DESCRIPTION
**Add a change in DesMume OGLRender.cpp.**

[DesMume has an auto Multisample level selection that apply:](https://github.com/Tatsuya79/desmume-1/blob/c48bffd1a68a9c55eceb089f0d4d2840cbacd529/desmume/src/OGLRender.h#L285)
-32x for x1 internal res
-16x for x2 to x4
-8x   for x5 to x8
-4x   above x8

16x is too expensive even on fast GPU in expensive scenes, even if that can look fine at first.
This commit makes it possible to select the AA level.

It needs a restart to apply the selected AA level (ON/OFF still works without restart, but will stay at the same AA value).