### PR TITLE
MSVC2017, UWP compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,10 @@ xcuserdata/
 /.cproject
 /config.log
 /.project
+
+## Windows binaries
+*.dll
+*.lib
+*.pdb
+*.exp
+*.manifest

--- a/appveyor_libretro.yml
+++ b/appveyor_libretro.yml
@@ -1,0 +1,33 @@
+version: 0.1.{build}
+
+shallow_clone: true
+
+image: Visual Studio 2017
+
+environment:
+  makefile_location: 'desmume\src\frontend\libretro'
+  makefile_name: Makefile
+  target_name: desmume_libretro
+
+configuration:
+  - release
+
+platform:
+  - windows_msvc2017_uwp_x64
+  - windows_msvc2017_uwp_x86
+  - windows_msvc2017_uwp_arm
+  - windows_msvc2017_desktop_x64
+  - windows_msvc2017_desktop_x86
+
+init:
+  - set Path=C:\msys64\usr\bin;%Path%
+
+build_script:
+  - cd %makefile_location%
+  - make -f %makefile_name% platform=%platform%
+
+artifacts:
+  - path: '**\%target_name%*.dll'
+  - path: '**\%target_name%*.lib'
+  - path: '**\%target_name%*.pdb'
+  - path: '**\libretro.h'

--- a/desmume/src/cheatSystem.cpp
+++ b/desmume/src/cheatSystem.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include "compat/fopen_utf8.h"
+#include <algorithm>
 
 CHEATS *cheats = NULL;
 CHEATSEARCH *cheatSearch = NULL;

--- a/desmume/src/frontend/libretro/Makefile.common
+++ b/desmume/src/frontend/libretro/Makefile.common
@@ -111,6 +111,7 @@ SOURCES_C += $(LIBRETRO_COMM_DIR)/memmap/memalign.c \
 				 $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
 				 $(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
 				 $(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c \
+				 $(LIBRETRO_COMM_DIR)/compat/compat_posix_string.c \
 				 $(LIBRETRO_COMM_DIR)/file/retro_dirent.c \
 				 $(LIBRETRO_COMM_DIR)/file/file_path.c \
 				 $(LIBRETRO_COMM_DIR)/string/stdstring.c \

--- a/desmume/src/frontend/libretro/Makefile.libretro
+++ b/desmume/src/frontend/libretro/Makefile.libretro
@@ -1,5 +1,12 @@
 DEBUG=0
 
+SPACE :=
+SPACE := $(SPACE) $(SPACE)
+BACKSLASH :=
+BACKSLASH := \$(BACKSLASH)
+filter_out1 = $(filter-out $(firstword $1),$1)
+filter_out2 = $(call filter_out1,$(call filter_out1,$1))
+
 ifneq ($(SANITIZER),)
    CFLAGS   := -fsanitize=$(SANITIZER) $(CFLAGS)
    CXXFLAGS := -fsanitize=$(SANITIZER) $(CXXFLAGS)
@@ -221,6 +228,98 @@ else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_$(platform).bc
    STATIC_LINKING = 1
 
+# Windows MSVC 2017 all architectures
+else ifneq (,$(findstring windows_msvc2017,$(platform)))
+
+    NO_GCC := 1
+
+	PlatformSuffix = $(subst windows_msvc2017_,,$(platform))
+	ifneq (,$(findstring desktop,$(PlatformSuffix)))
+		WinPartition = desktop
+		MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP -FS
+		LDFLAGS += -MANIFEST -LTCG:incremental -NXCOMPAT -DYNAMICBASE -DEBUG -OPT:REF -INCREMENTAL:NO -SUBSYSTEM:WINDOWS -MANIFESTUAC:"level='asInvoker' uiAccess='false'" -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1
+		LIBS += kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib
+	else ifneq (,$(findstring uwp,$(PlatformSuffix)))
+		WinPartition = uwp
+		MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WINDLL -D_UNICODE -DUNICODE -D__WRL_NO_DEFAULT_LIB__ -EHsc -FS
+		LDFLAGS += -APPCONTAINER -NXCOMPAT -DYNAMICBASE -MANIFEST:NO -LTCG -OPT:REF -SUBSYSTEM:CONSOLE -MANIFESTUAC:NO -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1 -DEBUG:FULL -WINMD:NO
+		LIBS += WindowsApp.lib
+	endif
+
+	CFLAGS += -DWIN32 $(MSVC2017CompileFlags)
+	CXXFLAGS += -DWIN32 $(MSVC2017CompileFlags)
+
+	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
+
+	CC  = cl.exe
+	CXX = cl.exe
+	LD = link.exe
+
+	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
+	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
+
+	ProgramFiles86w := $(shell cmd /c "echo %PROGRAMFILES(x86)%")
+	ProgramFiles86 := $(shell cygpath "$(ProgramFiles86w)")
+
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
+	WindowsSdkDir := $(WindowsSdkDir)
+
+	WindowsSDKVersion ?= $(firstword $(foreach folder,$(subst $(subst \,/,$(WindowsSdkDir)Include/),,$(wildcard $(call fix_path,$(WindowsSdkDir)Include\*))),$(if $(wildcard $(call fix_path,$(WindowsSdkDir)Include/$(folder)/um/Windows.h)),$(folder),)))$(BACKSLASH)
+	WindowsSDKVersion := $(WindowsSDKVersion)
+
+	VsInstallBuildTools = $(ProgramFiles86)/Microsoft Visual Studio/2017/BuildTools
+	VsInstallEnterprise = $(ProgramFiles86)/Microsoft Visual Studio/2017/Enterprise
+	VsInstallProfessional = $(ProgramFiles86)/Microsoft Visual Studio/2017/Professional
+	VsInstallCommunity = $(ProgramFiles86)/Microsoft Visual Studio/2017/Community
+
+	VsInstallRoot ?= $(shell if [ -d "$(VsInstallBuildTools)" ]; then echo "$(VsInstallBuildTools)"; fi)
+	ifeq ($(VsInstallRoot), )
+		VsInstallRoot = $(shell if [ -d "$(VsInstallEnterprise)" ]; then echo "$(VsInstallEnterprise)"; fi)
+	endif
+	ifeq ($(VsInstallRoot), )
+		VsInstallRoot = $(shell if [ -d "$(VsInstallProfessional)" ]; then echo "$(VsInstallProfessional)"; fi)
+	endif
+	ifeq ($(VsInstallRoot), )
+		VsInstallRoot = $(shell if [ -d "$(VsInstallCommunity)" ]; then echo "$(VsInstallCommunity)"; fi)
+	endif
+	VsInstallRoot := $(VsInstallRoot)
+
+	VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
+	VcCompilerToolsDir := $(VsInstallRoot)/VC/Tools/MSVC/$(VcCompilerToolsVer)
+
+	WindowsSDKSharedIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\shared")
+	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
+	WindowsSDKUMIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\um")
+	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
+	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
+
+	# For some reason the HostX86 compiler doesn't like compiling for x64
+	# ("no such file" opening a shared library), and vice-versa.
+	# Work around it for now by using the strictly x86 compiler for x86, and x64 for x64.
+	# NOTE: What about ARM?
+	ifneq (,$(findstring x64,$(TargetArchMoniker)))
+		VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX64
+	else
+		VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX86
+	endif
+
+	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/$(TargetArchMoniker)"):$(PATH)
+	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
+	INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/include")
+	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/lib/$(TargetArchMoniker)")
+	ifneq (,$(findstring uwp,$(PlatformSuffix)))
+		LIB := $(shell IFS=$$'\n'; cygpath -w "$(LIB)/store")
+	endif
+    
+	export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
+	export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir)
+	TARGET := $(TARGET_NAME)_libretro.dll $(TARGET_NAME)_libretro.lib $(TARGET_NAME)_libretro.pdb $(TARGET_NAME)_libretro.exp
+	PSS_STYLE :=2
+	LDFLAGS += -DLL
+
 # Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)
 	CC  = cl.exe
@@ -326,11 +425,35 @@ endif
 include Makefile.common
 
 ifeq ($(DEBUG), 1)
-   CFLAGS += -O0 -g
-   CXXFLAGS += -O0 -g
+    ifneq (,$(findstring msvc,$(platform)))
+        ifeq ($(STATIC_LINKING),1)
+            CFLAGS += -MTd
+            CXXFLAGS += -MTd
+        else
+            CFLAGS += -MDd
+            CXXFLAGS += -MDd
+        endif
+        CFLAGS += -Od -Zi -DDEBUG -D_DEBUG
+        CXXFLAGS += -Od -Zi -DDEBUG -D_DEBUG
+    else
+        CFLAGS += -O0 -g -DDEBUG
+        CXXFLAGS += -O0 -g -DDEBUG
+    endif
 else
-   CFLAGS += -O3 -DNDEBUG
-   CXXFLAGS += -O3 -DNDEBUG
+    ifneq (,$(findstring msvc,$(platform)))
+        ifeq ($(STATIC_LINKING),1)
+            CFLAGS += -MT
+            CXXFLAGS += -MT
+        else
+            CFLAGS += -MD
+            CXXFLAGS += -MD
+        endif
+        CFLAGS += -O2 -DNDEBUG
+        CXXFLAGS += -O2 -DNDEBUG
+    else
+        CFLAGS += -O3 -DNDEBUG
+        CXXFLAGS += -O3 -DNDEBUG
+    endif
 endif
 
 ifeq ($(RETRO_PROFILE),1)

--- a/desmume/src/frontend/libretro/Makefile.libretro
+++ b/desmume/src/frontend/libretro/Makefile.libretro
@@ -246,8 +246,8 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 		LIBS += WindowsApp.lib
 	endif
 
-	CFLAGS += -DWIN32 $(MSVC2017CompileFlags)
-	CXXFLAGS += -DWIN32 $(MSVC2017CompileFlags)
+	CFLAGS += -DWIN32 -DNOMINMAX $(MSVC2017CompileFlags)
+	CXXFLAGS += -DWIN32 -DNOMINMAX $(MSVC2017CompileFlags)
 
 	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
 
@@ -316,7 +316,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
     
 	export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
 	export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir)
-	TARGET := $(TARGET_NAME)_libretro.dll $(TARGET_NAME)_libretro.lib $(TARGET_NAME)_libretro.pdb $(TARGET_NAME)_libretro.exp
+	TARGET := $(TARGET_NAME)_libretro.dll
 	PSS_STYLE :=2
 	LDFLAGS += -DLL
 

--- a/desmume/src/frontend/windows/windriver.h
+++ b/desmume/src/frontend/windows/windriver.h
@@ -20,9 +20,12 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include "common.h"
+
+#ifndef __LIBRETRO__
 #include "CWindow.h"
 
 extern WINCLASS	*MainWindow;
+#endif
 
 class Lock {
 public:

--- a/desmume/src/gfx3d.cpp
+++ b/desmume/src/gfx3d.cpp
@@ -676,7 +676,7 @@ FORCEINLINE s64 GEM_Mul32x16To64(const s32 a, const s16 b)
 
 FORCEINLINE s64 GEM_Mul32x32To64(const s32 a, const s32 b)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 	return __emul(a,b);
 #else
 	return ((s64)a)*((s64)b);

--- a/desmume/src/libretro-common/include/math/fxp.h
+++ b/desmume/src/libretro-common/include/math/fxp.h
@@ -33,7 +33,7 @@
 
 static INLINE int64_t fx32_mul(const int32_t a, const int32_t b)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
    return __emul(a, b);
 #else
    return ((int64_t)a) * ((int64_t)b);
@@ -42,7 +42,7 @@ static INLINE int64_t fx32_mul(const int32_t a, const int32_t b)
 
 static INLINE int32_t fx32_shiftdown(const int64_t a)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 	return (int32_t)__ll_rshift(a, 12);
 #else
 	return (int32_t)(a >> 12);
@@ -51,7 +51,7 @@ static INLINE int32_t fx32_shiftdown(const int64_t a)
 
 static INLINE int64_t fx32_shiftup(const int32_t a)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 	return __ll_lshift(a, 12);
 #else
 	return ((int64_t)a) << 12;

--- a/desmume/src/metaspu/metaspu.cpp
+++ b/desmume/src/metaspu/metaspu.cpp
@@ -24,7 +24,7 @@
 #include <assert.h>
 
 //for pcsx2 method
-#if defined(_MSC_VER) || defined(HAVE_LIBSOUNDTOUCH) || defined(DESMUME_COCOA)
+#if defined(HAVE_LIBSOUNDTOUCH) || defined(DESMUME_COCOA)
 #include "SndOut.h"
 #endif
 
@@ -465,7 +465,7 @@ private:
 }; //NitsujaSynchronizer
 
 
-#if defined(_MSC_VER) || defined(HAVE_LIBSOUNDTOUCH) || defined(DESMUME_COCOA)
+#if defined(HAVE_LIBSOUNDTOUCH) || defined(DESMUME_COCOA)
 class PCSX2Synchronizer : public ISynchronizingAudioBuffer
 {
 public:
@@ -512,7 +512,7 @@ ISynchronizingAudioBuffer* metaspu_construct(ESynchMethod method)
 	{
 	case ESynchMethod_N: return new NitsujaSynchronizer();
 	case ESynchMethod_Z: return new ZeromusSynchronizer();
-#if defined(_MSC_VER) || defined(HAVE_LIBSOUNDTOUCH) || defined(DESMUME_COCOA)
+#if defined(HAVE_LIBSOUNDTOUCH) || defined(DESMUME_COCOA)
 	case ESynchMethod_P: return new PCSX2Synchronizer();
 #endif
 	default: return NULL;

--- a/desmume/src/movie.cpp
+++ b/desmume/src/movie.cpp
@@ -50,7 +50,7 @@ bool autoMovieBackup = true;
 
 #define MOVIE_VERSION 1
 
-#ifdef WIN32
+#if !defined(__LIBRETRO__) && defined(WIN32)
 #include "frontend/windows/main.h"
 #endif
 

--- a/desmume/src/path.h
+++ b/desmume/src/path.h
@@ -126,7 +126,7 @@ public:
 
 	void LoadModulePath()
 	{
-#if defined(HOST_WINDOWS)
+#if !defined(__LIBRETRO__) && defined(HOST_WINDOWS)
 
 		char *p;
 		ZeroMemory(pathToModule, sizeof(pathToModule));
@@ -141,7 +141,7 @@ public:
 		{
 			strcpy(pathToModule,_hack_alternateModulePath);
 		}
-#elif defined(DESMUME_COCOA)
+#elif !defined(__LIBRETRO__) && defined(DESMUME_COCOA)
 		std::string pathStr = Path::GetFileDirectoryPath(path);
 
 		strncpy(pathToModule, pathStr.c_str(), MAX_PATH);

--- a/desmume/src/path.h
+++ b/desmume/src/path.h
@@ -20,7 +20,7 @@
 #include <string.h>
 #include "types.h"
 
-#if defined(HOST_WINDOWS)
+#if !defined(__LIBRETRO__) && defined(HOST_WINDOWS)
 	#define WIN32_LEAN_AND_MEAN
 	#include <windows.h>
 	#include <direct.h>
@@ -197,7 +197,7 @@ public:
 
 	void GetDefaultPath(char *pathToDefault, const char *key, int maxCount)
 	{
-#ifdef HOST_WINDOWS
+#if !defined(__LIBRETRO__) && defined(HOST_WINDOWS)
 		std::string temp = (std::string)"." + DIRECTORY_DELIMITER_CHAR + pathToDefault;
 		strncpy(pathToDefault, temp.c_str(), maxCount);
 #else
@@ -207,7 +207,7 @@ public:
 
 	void ReadKey(char *pathToRead, const char *key)
 	{
-#ifdef HOST_WINDOWS
+#if !defined(__LIBRETRO__) && defined(HOST_WINDOWS)
 		GetPrivateProfileString(SECTION, key, key, pathToRead, MAX_PATH, IniName);
 		if(strcmp(pathToRead, key) == 0) {
 			//since the variables are all intialized in this file they all use MAX_PATH
@@ -234,7 +234,7 @@ public:
 		ReadKey(pathToFirmware, FIRMWAREKEY);
 		ReadKey(pathToLua, LUAKEY);
 		ReadKey(pathToSlot1D, SLOT1DKEY);
-#ifdef HOST_WINDOWS
+#if !defined(__LIBRETRO__) && defined(HOST_WINDOWS)
 		GetPrivateProfileString(SECTION, FORMATKEY, "%f_%s_%r", screenshotFormat, MAX_FORMAT, IniName);
 		savelastromvisit	= GetPrivateProfileBool(SECTION, LASTVISITKEY, true, IniName);
 		currentimageformat	= (ImageFormat)GetPrivateProfileInt(SECTION, DEFAULTFORMATKEY, PNG, IniName);

--- a/desmume/src/rtc.cpp
+++ b/desmume/src/rtc.cpp
@@ -24,7 +24,7 @@
 #include "armcpu.h"
 #include <string.h>
 #include "saves.h"
-#ifdef WIN32
+#if !defined(__LIBRETRO__) && defined(WIN32)
 #include "frontend/windows/main.h"
 #endif
 #include "movie.h"

--- a/desmume/src/saves.cpp
+++ b/desmume/src/saves.cpp
@@ -57,7 +57,7 @@
 
 #include "path.h"
 
-#ifdef HOST_WINDOWS
+#if !defined(__LIBRETRO__) && defined(HOST_WINDOWS)
 #include "frontend/windows/main.h"
 #endif
 

--- a/desmume/src/utils/dlditool.cpp
+++ b/desmume/src/utils/dlditool.cpp
@@ -202,6 +202,7 @@ addr_t quickFind (const data_t* data, const data_t* search, size_t dataLen, size
 	return -1;
 }
 
+#ifndef __LIBRETRO__
 FILE *openDLDIFile(const char *argv0, char *dldiFileName ) {
 
 
@@ -305,6 +306,7 @@ FILE *openDLDIFile(const char *argv0, char *dldiFileName ) {
 
 	return (FILE*)fopen_utf8(appPath,"rb");		// no more places to check, just return this handle
 }
+#endif
 
 //int main(int argc, char* argv[])
 //{

--- a/desmume/src/utils/libfat/directory.cpp
+++ b/desmume/src/utils/libfat/directory.cpp
@@ -168,12 +168,13 @@ static size_t _FAT_directory_ucs2tombs (char* dst, const ucs2_t* src, size_t len
 	mbstate_t ps = {0};
 	size_t count = 0;
 	int bytes;
-	char* buff = (char*)alloca(MB_CUR_MAX);
+	char* buff = (char*)malloc(MB_CUR_MAX);
 	int i;
 	
 	while (count < len - 1 && *src != '\0') {
 		bytes = wcrtomb (buff, *src, &ps);
 		if (bytes < 0) {
+			free(buff);
 			return -1;
 		}
 		if (count + bytes < len && bytes > 0) {
@@ -188,6 +189,7 @@ static size_t _FAT_directory_ucs2tombs (char* dst, const ucs2_t* src, size_t len
 	}
 	*dst = L'\0';
 	
+	free(buff);
 	return count;
 }
 

--- a/desmume/src/version.cpp
+++ b/desmume/src/version.cpp
@@ -33,7 +33,7 @@
 
 //TODO - it isn't possible to build a core without a frontend, so really this belongs with frontend modules
 //the only stuff that belongs in the core is major/minor/build versions which are (in principle) used for versioning savestates and movies and such..
-#if defined(HOST_WINDOWS) || defined(DESMUME_COCOA)
+#if !defined(_MSC_VER) && (defined(HOST_WINDOWS) || defined(DESMUME_COCOA))
 	#include "scmrev.h"
 	#define SVN_REV_STR SCM_DESC_STR
 #else


### PR DESCRIPTION
Changes to have core compile on MSVC2017, for both desktop and UWP.
As VFS support is not included with this PR, the core doesn't yet work in UWP.

Works when tested against Retroarch in desktop configuration, when built on MSVC and GCC.