### PR TITLE
Adding VFS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DeSmuME
-[![AppVeyor CI Build Status](https://ci.appveyor.com/api/projects/status/abfd7jm09wnmxyvu?svg=true)](https://ci.appveyor.com/project/zeromus/desmume)
+[![AppVeyor CI Build Status](https://ci.appveyor.com/api/projects/status/abfd7jm09wnmxyvu?svg=true)](https://ci.appveyor.com/project/bparker06/desmume)
 
 DeSmuME is a Nintendo DS emulator.
 

--- a/desmume/src/MMU.cpp
+++ b/desmume/src/MMU.cpp
@@ -3610,7 +3610,9 @@ void FASTCALL _MMU_ARM9_write08(u32 adr, u8 val)
 					if(nds.ensataEmulation)
 					{
 						printf("%c",val);
+						#ifndef __LIBRETRO__
 						fflush(stdout);
+						#endif
 					}
 					break;
 					

--- a/desmume/src/MMU.cpp
+++ b/desmume/src/MMU.cpp
@@ -48,6 +48,8 @@
 #include "SPU.h"
 #include "emufile.h"
 
+#include "streams/file_stream.h"
+
 #ifdef DO_ASSERT_UNALIGNED
 #define ASSERT_UNALIGNED(x) assert(x)
 #else
@@ -940,7 +942,7 @@ void MMU_Init(void)
 void MMU_DeInit(void) {
 	LOG("MMU deinit\n");
 	if (MMU.fw.fp)
-		fclose(MMU.fw.fp);
+		filestream_close(MMU.fw.fp);
 	mc_free(&MMU.fw);      
 
 	slot1_Shutdown();

--- a/desmume/src/NDSSystem.cpp
+++ b/desmume/src/NDSSystem.cpp
@@ -57,7 +57,6 @@
 #include "SPU.h"
 #include "wifi.h"
 #include "Database.h"
-#include "streams/file_stream_transforms.h"
 
 #ifdef GDB_STUB
 #include "gdbstub.h"

--- a/desmume/src/NDSSystem.cpp
+++ b/desmume/src/NDSSystem.cpp
@@ -57,7 +57,7 @@
 #include "SPU.h"
 #include "wifi.h"
 #include "Database.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 #ifdef GDB_STUB
 #include "gdbstub.h"

--- a/desmume/src/NDSSystem.cpp
+++ b/desmume/src/NDSSystem.cpp
@@ -2159,7 +2159,7 @@ static void PrepareBiosARM7()
 	if(CommonSettings.UseExtBIOS == true)
 	{
 		//read arm7 bios from inputfile and flag it if it succeeds
-		FILE *arm7inf = (FILE*)fopen_utf8(CommonSettings.ARM7BIOS,"rb");
+		FILE *arm7inf = (FILE*)fopen(CommonSettings.ARM7BIOS,"rb");
 		if (arm7inf) 
 		{
 			if (fread(MMU.ARM7_BIOS,1,16384,arm7inf) == 16384)
@@ -2217,7 +2217,7 @@ static void PrepareBiosARM9()
 	if(CommonSettings.UseExtBIOS == true)
 	{
 		//read arm9 bios from inputfile and flag it if it succeeds
-		FILE* arm9inf = (FILE*)fopen_utf8(CommonSettings.ARM9BIOS,"rb");
+		FILE* arm9inf = (FILE*)fopen(CommonSettings.ARM9BIOS,"rb");
 		if (arm9inf) 
 		{
 			if (fread(MMU.ARM9_BIOS,1,4096,arm9inf) == 4096) 
@@ -2355,7 +2355,7 @@ static void PrepareLogfiles()
 		fclose(fp_dis7);
 		fp_dis7 = NULL;
 	}
-	fp_dis7 = (FILE*)fopen_utf8("D:\\desmume_dis7.asm", "w");
+	fp_dis7 = (FILE*)fopen("D:\\desmume_dis7.asm", "w");
 #endif
 
 #ifdef LOG_ARM9
@@ -2364,7 +2364,7 @@ static void PrepareLogfiles()
 		fclose(fp_dis9);
 		fp_dis9 = NULL;
 	}
-	fp_dis9 = (FILE*)fopen_utf8("D:\\desmume_dis9.asm", "w");
+	fp_dis9 = (FILE*)fopen("D:\\desmume_dis9.asm", "w");
 #endif
 }
 

--- a/desmume/src/ROMReader.cpp
+++ b/desmume/src/ROMReader.cpp
@@ -79,15 +79,6 @@ struct STDROMReaderData
 
 void* STDROMReaderInit(const char* filename)
 {
-#ifndef _WIN32
-	struct stat sb;
-	if (stat_utf8(filename, &sb) == -1)
-		return 0;
-
- 	if ((sb.st_mode & S_IFMT) != S_IFREG)
-		return 0;
-#endif
-
 	FILE* inf = (FILE*)fopen(filename, "rb");
 	if(!inf) return NULL;
 

--- a/desmume/src/ROMReader.cpp
+++ b/desmume/src/ROMReader.cpp
@@ -88,7 +88,7 @@ void* STDROMReaderInit(const char* filename)
 		return 0;
 #endif
 
-	FILE* inf = (FILE*)fopen_utf8(filename, "rb");
+	FILE* inf = (FILE*)fopen(filename, "rb");
 	if(!inf) return NULL;
 
 	STDROMReaderData* ret = new STDROMReaderData();

--- a/desmume/src/ROMReader.cpp
+++ b/desmume/src/ROMReader.cpp
@@ -25,7 +25,7 @@
 #include <zzip/zzip.h>
 #endif
 
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 #if defined(_WIN32) && defined(_MSVC_VER) 
 #define stat(...) stat_utf8(__VA_ARGS__)

--- a/desmume/src/SPU.cpp
+++ b/desmume/src/SPU.cpp
@@ -43,7 +43,7 @@
 #include "matrix.h"
 #include "utils/bits.h"
 
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 static inline s16 read16(u32 addr) { return (s16)_MMU_read16<ARMCPU_ARM7,MMU_AT_DEBUG>(addr); }
 static inline u8 read08(u32 addr) { return _MMU_read08<ARMCPU_ARM7,MMU_AT_DEBUG>(addr); }

--- a/desmume/src/SPU.cpp
+++ b/desmume/src/SPU.cpp
@@ -1518,7 +1518,7 @@ static void SPU_MixAudio_Advanced(bool actuallyMix, SPU_struct *SPU, int length)
 					cap.runtime.fifo.enqueue(capout[capchan]);
 
 					//static FILE* fp = NULL;
-					//if(!fp) fp = (FILE*)fopen_utf8("d:\\capout.raw","wb");
+					//if(!fp) fp = (FILE*)fopen("d:\\capout.raw","wb");
 					//fwrite(&sample,2,1,fp);
 					
 					if (cap.bits8)
@@ -1853,7 +1853,7 @@ bool WavWriter::open(const std::string & fname)
 	chunk_struct data;
 	size_t elems_written = 0;
 
-	if ((spufp = (FILE*)fopen_utf8(fname.c_str(), "wb")) == NULL)
+	if ((spufp = (FILE*)fopen(fname.c_str(), "wb")) == NULL)
 		return false;
 
 	// Do wave header

--- a/desmume/src/SPU.cpp
+++ b/desmume/src/SPU.cpp
@@ -43,8 +43,6 @@
 #include "matrix.h"
 #include "utils/bits.h"
 
-#include "streams/file_stream_transforms.h"
-
 static inline s16 read16(u32 addr) { return (s16)_MMU_read16<ARMCPU_ARM7,MMU_AT_DEBUG>(addr); }
 static inline u8 read08(u32 addr) { return _MMU_read08<ARMCPU_ARM7,MMU_AT_DEBUG>(addr); }
 static inline s8 read_s8(u32 addr) { return (s8)_MMU_read08<ARMCPU_ARM7,MMU_AT_DEBUG>(addr); }

--- a/desmume/src/addons/slot1_retail_mcrom_debug.cpp
+++ b/desmume/src/addons/slot1_retail_mcrom_debug.cpp
@@ -136,7 +136,7 @@ public:
 						}
 						tmp = pathData + tmp;
 
-						fpROM = (FILE*)fopen_utf8(tmp.c_str(), "rb");
+						fpROM = (FILE*)fopen(tmp.c_str(), "rb");
 						if (fpROM)
 						{
 							bFromFile = true;

--- a/desmume/src/addons/slot1_retail_mcrom_debug.cpp
+++ b/desmume/src/addons/slot1_retail_mcrom_debug.cpp
@@ -31,7 +31,7 @@
 #include "../path.h"
 #include "../NDSSystem.h"
 #include "../utils/fsnitro.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 class Slot1_Retail_DEBUG : public ISlot1Interface, public ISlot1Comp_Protocol_Client
 {

--- a/desmume/src/arm_jit.cpp
+++ b/desmume/src/arm_jit.cpp
@@ -4382,7 +4382,7 @@ void arm_jit_close()
 
 		char buf[MAX_PATH] = {0};
 		sprintf(buf, "desmume_jit%c_counter.profiler", proc==0?'9':'7');
-		FILE *fp = fopen_utf8(buf, "w");
+		FILE *fp = fopen(buf, "w");
 		if (fp)
 		{
 			if (!gameInfo.isHomebrew())
@@ -4418,7 +4418,7 @@ void arm_jit_close()
 
 #if (PROFILER_JIT_LEVEL > 1)
 		sprintf(buf, "desmume_jit%c_entry.profiler", proc==0?'9':'7');
-		fp = fopen_utf8(buf, "w");
+		fp = fopen(buf, "w");
 		if (fp)
 		{
 			u32 count = 0;

--- a/desmume/src/arm_jit.cpp
+++ b/desmume/src/arm_jit.cpp
@@ -18,7 +18,6 @@
 */
 
 #include "types.h"
-#include "streams/file_stream_transforms.h"
 
 #ifdef HAVE_JIT
 #if !defined(HOST_32) && !defined(HOST_64)
@@ -4208,7 +4207,9 @@ static u32 compile_basicblock()
 	ArmOpCompiled f = (ArmOpCompiled)c.make();
 	if(c.getError())
 	{
+#if LOG_JIT
 		fprintf(stderr, "JIT error at %s%c-%08X: %s\n", bb_thumb?"THUMB":"ARM", PROCNUM?'7':'9', start_adr, getErrorString(c.getError()));
+#endif
 		f = op_decode[PROCNUM][bb_thumb];
 	}
 #if LOG_JIT

--- a/desmume/src/arm_jit.cpp
+++ b/desmume/src/arm_jit.cpp
@@ -18,7 +18,7 @@
 */
 
 #include "types.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 #ifdef HAVE_JIT
 #if !defined(HOST_32) && !defined(HOST_64)

--- a/desmume/src/cheatSystem.cpp
+++ b/desmume/src/cheatSystem.cpp
@@ -27,7 +27,6 @@
 #include <stdint.h>
 #endif
 
-#include "streams/file_stream_transforms.h"
 #include <algorithm>
 
 CHEATS *cheats = NULL;
@@ -788,7 +787,7 @@ BOOL CHEATS::save()
 		fprintf(flist, "; DeSmuME cheats file. VERSION %i.%03i\n", CHEAT_VERSION_MAJOR, CHEAT_VERSION_MINOR);
 		fprintf(flist, "Name=%s\n", gameInfo.ROMname);
 		fprintf(flist, "Serial=%s\n", gameInfo.ROMserial);
-		fputs("\n; cheats list\n", flist);
+		fprintf(flist, "%s", "\n; cheats list\n");
 		for (size_t i = 0;  i < list.size(); i++)
 		{
 			if (list[i].num == 0) continue;
@@ -821,7 +820,7 @@ BOOL CHEATS::save()
 			cheatLineStr += trim(list[i].description);
 			fprintf(flist, "%s\n", cheatLineStr.c_str());
 		}
-		fputs("\n", flist);
+		fputc('\n', flist);
 		fclose(flist);
 		return TRUE;
 	}

--- a/desmume/src/cheatSystem.cpp
+++ b/desmume/src/cheatSystem.cpp
@@ -27,7 +27,7 @@
 #include <stdint.h>
 #endif
 
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 #include <algorithm>
 
 CHEATS *cheats = NULL;

--- a/desmume/src/cheatSystem.cpp
+++ b/desmume/src/cheatSystem.cpp
@@ -29,6 +29,8 @@
 
 #include <algorithm>
 
+#include "streams/file_stream_transforms.h"
+
 CHEATS *cheats = NULL;
 CHEATSEARCH *cheatSearch = NULL;
 

--- a/desmume/src/cheatSystem.cpp
+++ b/desmume/src/cheatSystem.cpp
@@ -781,7 +781,7 @@ BOOL CHEATS::save()
 {
 	const char	*types[] = {"DS", "AR", "CB"};
 	std::string	cheatLineStr = "";
-	FILE		*flist = (FILE*)fopen_utf8((char *)filename, "w");
+	FILE		*flist = (FILE*)fopen((char *)filename, "w");
 
 	if (flist)
 	{
@@ -850,7 +850,7 @@ char *CHEATS::clearCode(char *s)
 
 BOOL CHEATS::load()
 {
-	FILE *flist = (FILE*)fopen_utf8((char *)filename, "r");
+	FILE *flist = (FILE*)fopen((char *)filename, "r");
 	if (flist == NULL)
 	{
 		return FALSE;
@@ -1436,7 +1436,7 @@ bool CHEATSEXPORT::load(char *path)
 {
 	error = 0;
 
-	fp = (FILE*)fopen_utf8(path, "rb");
+	fp = (FILE*)fopen(path, "rb");
 	if (!fp)
 	{
 		printf("Error open database\n");

--- a/desmume/src/cheatSystem.h
+++ b/desmume/src/cheatSystem.h
@@ -22,8 +22,6 @@
 #include <vector>
 #include "types.h"
 
-#include "streams/file_stream_transforms.h"
-
 #define CHEAT_VERSION_MAJOR			2
 #define CHEAT_VERSION_MINOR			0
 #define MAX_CHEAT_LIST				100
@@ -35,6 +33,8 @@
 #define CHEAT_TYPE_INTERNAL 0
 #define CHEAT_TYPE_AR 1
 #define CHEAT_TYPE_CODEBREAKER 2
+
+typedef struct RFILE RFILE;
 
 struct CHEATS_LIST
 {
@@ -146,7 +146,7 @@ class CHEATSEXPORT
 private:
 	CHEATS_DB_TYPE		type;
 	bool				encrypted;
-	FILE				*fp;
+	RFILE				*fp;
 	u32					fsize;
 	u32					dataSize;
 	u32					encOffset;

--- a/desmume/src/cheatSystem.h
+++ b/desmume/src/cheatSystem.h
@@ -22,6 +22,8 @@
 #include <vector>
 #include "types.h"
 
+#include "streams/file_stream_transforms.h"
+
 #define CHEAT_VERSION_MAJOR			2
 #define CHEAT_VERSION_MINOR			0
 #define MAX_CHEAT_LIST				100

--- a/desmume/src/debug.cpp
+++ b/desmume/src/debug.cpp
@@ -29,7 +29,7 @@
 #include "utils/xstring.h"
 #include "movie.h"
 
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 #ifdef HAVE_LUA
 #include "lua-engine.h"

--- a/desmume/src/debug.cpp
+++ b/desmume/src/debug.cpp
@@ -108,7 +108,7 @@ void HandleDebugEvent_CacheMiss()
 	extern int currFrameCounter;
 	if(currFrameCounter<200) return;
 	static FILE* outf = NULL;
-	if(!outf) outf = (FILE*)fopen_utf8("c:\\miss.txt","wb");
+	if(!outf) outf = (FILE*)fopen("c:\\miss.txt","wb");
 	fprintf(outf,"%05d,%08X,%d\n",currFrameCounter,DebugEventData.addr,DebugEventData.size);
 }
 

--- a/desmume/src/debug.cpp
+++ b/desmume/src/debug.cpp
@@ -29,8 +29,6 @@
 #include "utils/xstring.h"
 #include "movie.h"
 
-#include "streams/file_stream_transforms.h"
-
 #ifdef HAVE_LUA
 #include "lua-engine.h"
 #endif

--- a/desmume/src/debug.h
+++ b/desmume/src/debug.h
@@ -27,8 +27,6 @@
 #include "types.h"
 #include "mem.h"
 
-#include "streams/file_stream_transforms.h"
-
 struct armcpu_t;
 class EMUFILE;
 

--- a/desmume/src/debug.h
+++ b/desmume/src/debug.h
@@ -27,6 +27,8 @@
 #include "types.h"
 #include "mem.h"
 
+#include "streams/file_stream_transforms.h"
+
 struct armcpu_t;
 class EMUFILE;
 

--- a/desmume/src/emufile.cpp
+++ b/desmume/src/emufile.cpp
@@ -64,11 +64,7 @@ size_t EMUFILE_MEMORY::_fread(const void *ptr, size_t bytes){
 void EMUFILE_FILE::truncate(s32 length)
 {
 	::fflush(fp);
-	#ifdef HOST_WINDOWS 
-		_chsize(_fileno(fp),length);
-	#else
-		ftruncate(fileno(fp),length);
-	#endif
+	filestream_truncate(fp, length);
 	fclose(fp);
 	fp = NULL;
 	open(fname.c_str(),mode);

--- a/desmume/src/emufile.cpp
+++ b/desmume/src/emufile.cpp
@@ -23,25 +23,11 @@ THE SOFTWARE.
 */
 
 #include "emufile.h"
-#include "streams/file_stream.h"
+
+#define SKIP_STDIO_REDEFINES
+#include "streams/file_stream_transforms.h"
 
 #include <vector>
-
-RETRO_BEGIN_DECLS
-RFILE* rfopen(const char *path, const char *mode);
-int rfclose(RFILE* stream);
-long rftell(RFILE* stream);
-int rfseek(RFILE* stream, long offset, int origin);
-size_t rfread(void* buffer, size_t elementSize, size_t elementCount, RFILE* stream);
-char *rfgets(char *buffer, int maxCount, RFILE* stream);
-int rfgetc(RFILE* stream);
-size_t rfwrite(void const* buffer, size_t elementSize, size_t elementCount, RFILE* stream);
-int rfputc(int character, RFILE * stream);
-int rfflush(RFILE * stream);
-int rfprintf(RFILE * stream, const char * format, ...);
-int rferror(RFILE* stream);
-int rfeof(RFILE* stream);
-RETRO_END_DECLS
 
 bool EMUFILE::readAllBytes(std::vector<u8>* dstbuf, const std::string& fname)
 {

--- a/desmume/src/emufile.h
+++ b/desmume/src/emufile.h
@@ -335,7 +335,9 @@ public:
 	virtual int fprintf(const char *format, ...) {
 		va_list argptr;
 		va_start(argptr, format);
-		int ret = ::vfprintf(fp, format, argptr);
+		static char buffer[1024];
+		int string_len = ::vsprintf(buffer, format, argptr);
+		int ret = ::fwrite(buffer, sizeof(char), string_len, fp);
 		va_end(argptr);
 		return ret;
 	};

--- a/desmume/src/emufile.h
+++ b/desmume/src/emufile.h
@@ -43,7 +43,7 @@ THE SOFTWARE.
 #include <unistd.h>
 #endif
 
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 class EMUFILE_MEMORY;
 

--- a/desmume/src/emufile.h
+++ b/desmume/src/emufile.h
@@ -281,7 +281,7 @@ public:
 
 class EMUFILE_FILE : public EMUFILE { 
 protected:
-	FILE* fp;
+	RFILE* fp;
 	std::string fname;
 	char mode[16];
 	long mFilePosition;
@@ -317,7 +317,7 @@ public:
 
 	virtual ~EMUFILE_FILE() {
 		if(NULL != fp)
-			fclose(fp);
+			rfclose(fp);
 	}
 
 	virtual FILE *get_fp() {
@@ -337,16 +337,16 @@ public:
 		va_start(argptr, format);
 		static char buffer[1024];
 		int string_len = ::vsprintf(buffer, format, argptr);
-		int ret = ::fwrite(buffer, sizeof(char), string_len, fp);
+		int ret = ::rfwrite(buffer, sizeof(char), string_len, fp);
 		va_end(argptr);
 		return ret;
 	};
 
 	virtual int fgetc() {
-		return ::fgetc(fp);
+		return ::rfgetc(fp);
 	}
 	virtual int fputc(int c) {
-		return ::fputc(c, fp);
+		return ::rfputc(c, fp);
 	}
 
 	virtual size_t _fread(const void *ptr, size_t bytes);
@@ -365,7 +365,7 @@ public:
 	}
 
 	virtual void fflush() {
-		::fflush(fp);
+		::rfflush(fp);
 	}
 
 };

--- a/desmume/src/emufile.h
+++ b/desmume/src/emufile.h
@@ -301,7 +301,7 @@ private:
 		mPositionCacheEnabled = false;
 		mCondition = eCondition_Clean;
 		mFilePosition = 0;
-		fp = (FILE*)fopen_utf8(fname,mode);
+		fp = (FILE*)fopen(fname,mode);
 		if(!fp)
 			failbit = true;
 		this->fname = fname;

--- a/desmume/src/firmware.cpp
+++ b/desmume/src/firmware.cpp
@@ -23,6 +23,8 @@
 #include "encrypt.h"
 #include "wifi.h"
 
+#include "streams/file_stream_transforms.h"
+
 #define DFC_ID_CODE	"DeSmuME Firmware User Settings"
 #define DFC_ID_SIZE	sizeof(DFC_ID_CODE)
 #define USER_SETTINGS_SIZE 0x100

--- a/desmume/src/firmware.cpp
+++ b/desmume/src/firmware.cpp
@@ -22,7 +22,6 @@
 #include "path.h"
 #include "encrypt.h"
 #include "wifi.h"
-#include "streams/file_stream_transforms.h"
 
 #define DFC_ID_CODE	"DeSmuME Firmware User Settings"
 #define DFC_ID_SIZE	sizeof(DFC_ID_CODE)

--- a/desmume/src/firmware.cpp
+++ b/desmume/src/firmware.cpp
@@ -22,7 +22,7 @@
 #include "path.h"
 #include "encrypt.h"
 #include "wifi.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 #define DFC_ID_CODE	"DeSmuME Firmware User Settings"
 #define DFC_ID_SIZE	sizeof(DFC_ID_CODE)

--- a/desmume/src/firmware.cpp
+++ b/desmume/src/firmware.cpp
@@ -256,7 +256,7 @@ bool CFIRMWARE::load()
 	if (strlen(CommonSettings.Firmware) == 0)
 		return false;
 	
-	FILE	*fp = (FILE*)fopen_utf8(CommonSettings.Firmware, "rb");
+	FILE	*fp = (FILE*)fopen(CommonSettings.Firmware, "rb");
 	if (!fp)
 		return false;
 	fseek(fp, 0, SEEK_END);
@@ -517,7 +517,7 @@ bool CFIRMWARE::loadSettings()
 	if (!CommonSettings.UseExtFirmware) return false;
 	if (!CommonSettings.UseExtFirmwareSettings) return false;
 
-	FILE *fp = (FILE*)fopen_utf8(MMU.fw.userfile, "rb");
+	FILE *fp = (FILE*)fopen(MMU.fw.userfile, "rb");
 	if (fp)
 	{
 		fseek(fp, 0, SEEK_END);
@@ -575,7 +575,7 @@ bool CFIRMWARE::saveSettings()
 	}
 	
 	printf("Firmware: saving config");
-	FILE *fp = (FILE*)fopen_utf8(MMU.fw.userfile, "wb");
+	FILE *fp = (FILE*)fopen(MMU.fw.userfile, "wb");
 	if (fp)
 	{
 		u8 *usr = new u8[DFC_FILE_SIZE];

--- a/desmume/src/firmware.h
+++ b/desmume/src/firmware.h
@@ -21,7 +21,7 @@
 #include <string>
 #include "types.h"
 
-#include "streams/file_stream_transforms.h"
+struct RFILE;
 
 #define NDS_FW_SIZE_V1 (256 * 1024)		/* size of fw memory on nds v1 */
 #define NDS_FW_SIZE_V2 (512 * 1024)		/* size of fw memory on nds v2 */
@@ -110,7 +110,7 @@ struct fw_memory_chip
 	BOOL writeable_buffer;	//is "data" writeable ?
 	int type; //type of Memory
 	char *filename;
-	FILE *fp;
+	struct RFILE *fp;
 	
 	// needs only for firmware
 	bool isFirmware;

--- a/desmume/src/firmware.h
+++ b/desmume/src/firmware.h
@@ -21,6 +21,8 @@
 #include <string>
 #include "types.h"
 
+#include "streams/file_stream_transforms.h"
+
 #define NDS_FW_SIZE_V1 (256 * 1024)		/* size of fw memory on nds v1 */
 #define NDS_FW_SIZE_V2 (512 * 1024)		/* size of fw memory on nds v2 */
 

--- a/desmume/src/frontend/libretro/Makefile.common
+++ b/desmume/src/frontend/libretro/Makefile.common
@@ -106,6 +106,7 @@ SOURCES_C   := $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c
 
 SOURCES_C += $(LIBRETRO_COMM_DIR)/memmap/memalign.c \
 				 $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
+				 $(LIBRETRO_COMM_DIR)/streams/file_stream_transforms.c \
 				 $(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c \
 				 $(LIBRETRO_COMM_DIR)/features/features_cpu.c \
 				 $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \

--- a/desmume/src/frontend/libretro/libretro.cpp
+++ b/desmume/src/frontend/libretro/libretro.cpp
@@ -19,6 +19,8 @@
 #include "common.h"
 #include "path.h"
 
+#include "streams/file_stream.h"
+
 #ifdef HAVE_OPENGL
 #include "OGLRender.h"
 #include "OGLRender_3_2.h"
@@ -1349,6 +1351,7 @@ void retro_set_input_state(retro_input_state_t cb) { input_cb = cb; }
 
 void retro_set_environment(retro_environment_t cb)
 {
+   struct retro_vfs_interface_info vfs_iface_info;
    environ_cb = cb;
 
    static const retro_variable values[] =
@@ -1403,6 +1406,11 @@ void retro_set_environment(retro_environment_t cb)
    };
 
    environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, (void*)values);
+
+   vfs_iface_info.required_interface_version = FILESTREAM_REQUIRED_VFS_VERSION;
+   vfs_iface_info.iface                      = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
+	   filestream_vfs_init(&vfs_iface_info);
 }
 
 

--- a/desmume/src/libretro-common/include/libretro.h
+++ b/desmume/src/libretro-common/include/libretro.h
@@ -1030,6 +1030,10 @@ typedef int (RETRO_CALLCONV *retro_vfs_close_t)(struct retro_vfs_file_handle *st
  * Introduced in VFS API v1 */
 typedef int64_t (RETRO_CALLCONV *retro_vfs_size_t)(struct retro_vfs_file_handle *stream);
 
+/* Truncate file to specified size. Returns 0 on success or -1 on error
+ * Introduced in VFS API v2 */
+typedef int (RETRO_CALLCONV *retro_vfs_truncate_t)(struct retro_vfs_file_handle *stream, int64_t length);
+
 /* Get the current read / write position for the file. Returns - 1 for error.
  * Introduced in VFS API v1 */
 typedef int64_t (RETRO_CALLCONV *retro_vfs_tell_t)(struct retro_vfs_file_handle *stream);
@@ -1064,6 +1068,7 @@ struct retro_vfs_interface
 	retro_vfs_open_t open;
 	retro_vfs_close_t close;
 	retro_vfs_size_t size;
+      retro_vfs_truncate_t truncate;
 	retro_vfs_tell_t tell;
 	retro_vfs_seek_t seek;
 	retro_vfs_read_t read;

--- a/desmume/src/libretro-common/include/libretro.h
+++ b/desmume/src/libretro-common/include/libretro.h
@@ -1064,11 +1064,11 @@ typedef int (RETRO_CALLCONV *retro_vfs_rename_t)(const char *old_path, const cha
 
 struct retro_vfs_interface
 {
+      /* VFS API v1 */
 	retro_vfs_get_path_t get_path;
 	retro_vfs_open_t open;
 	retro_vfs_close_t close;
 	retro_vfs_size_t size;
-      retro_vfs_truncate_t truncate;
 	retro_vfs_tell_t tell;
 	retro_vfs_seek_t seek;
 	retro_vfs_read_t read;
@@ -1076,6 +1076,9 @@ struct retro_vfs_interface
 	retro_vfs_flush_t flush;
 	retro_vfs_remove_t remove;
 	retro_vfs_rename_t rename;
+      
+      /* VFS API v2 */
+      retro_vfs_truncate_t truncate;
 };
 
 struct retro_vfs_interface_info

--- a/desmume/src/libretro-common/include/streams/file_stream.h
+++ b/desmume/src/libretro-common/include/streams/file_stream.h
@@ -37,17 +37,19 @@
 
 #include <stdarg.h>
 
-#define FILESTREAM_REQUIRED_VFS_VERSION 1
+#define FILESTREAM_REQUIRED_VFS_VERSION 2
 
 RETRO_BEGIN_DECLS
 
 typedef struct RFILE RFILE;
 
-#define FILESTREAM_REQUIRED_VFS_VERSION 1
+#define FILESTREAM_REQUIRED_VFS_VERSION 2
 
 void filestream_vfs_init(const struct retro_vfs_interface_info* vfs_info);
 
 int64_t filestream_get_size(RFILE *stream);
+
+int filestream_truncate(RFILE *stream, int64_t length);
 
 /**
  * filestream_open:
@@ -66,7 +68,7 @@ int64_t filestream_read(RFILE *stream, void *data, int64_t len);
 
 int64_t filestream_write(RFILE *stream, const void *data, int64_t len);
 
-int64_t filestream_tell(RFILE *stream);
+int64_t filestream_tell(RFILE *stream);;
 
 void filestream_rewind(RFILE *stream);
 

--- a/desmume/src/libretro-common/include/streams/file_stream_transforms.h
+++ b/desmume/src/libretro-common/include/streams/file_stream_transforms.h
@@ -31,6 +31,8 @@ RETRO_BEGIN_DECLS
 
 #define FILE RFILE
 
+#ifndef SKIP_STDIO_REDEFINES
+
 #undef fopen
 #undef fclose
 #undef ftell
@@ -58,6 +60,8 @@ RETRO_BEGIN_DECLS
 #define fprintf rfprintf
 #define ferror rferror
 #define feof rfeof
+
+#endif
 
 RFILE* rfopen(const char *path, const char *mode);
 

--- a/desmume/src/libretro-common/include/streams/file_stream_transforms.h
+++ b/desmume/src/libretro-common/include/streams/file_stream_transforms.h
@@ -40,6 +40,7 @@ RETRO_BEGIN_DECLS
 #undef fgetc
 #undef fwrite
 #undef fputc
+#undef fflush
 #undef fprintf
 #undef ferror
 #undef feof

--- a/desmume/src/libretro-common/include/streams/file_stream_transforms.h
+++ b/desmume/src/libretro-common/include/streams/file_stream_transforms.h
@@ -29,9 +29,9 @@
 
 RETRO_BEGIN_DECLS
 
-#define FILE RFILE
-
 #ifndef SKIP_STDIO_REDEFINES
+
+#define FILE RFILE
 
 #undef fopen
 #undef fclose

--- a/desmume/src/libretro-common/include/streams/file_stream_transforms.h
+++ b/desmume/src/libretro-common/include/streams/file_stream_transforms.h
@@ -53,6 +53,7 @@ RETRO_BEGIN_DECLS
 #define fgetc rfgetc
 #define fwrite rfwrite
 #define fputc rfputc
+#define fflush rfflush
 #define fprintf rfprintf
 #define ferror rferror
 #define feof rfeof
@@ -76,6 +77,8 @@ size_t rfwrite(void const* buffer,
    size_t elementSize, size_t elementCount, RFILE* stream);
 
 int rfputc(int character, RFILE * stream);
+
+int rfflush(RFILE * stream);
 
 int rfprintf(RFILE * stream, const char * format, ...);
 

--- a/desmume/src/libretro-common/include/vfs/vfs_implementation.h
+++ b/desmume/src/libretro-common/include/vfs/vfs_implementation.h
@@ -46,6 +46,8 @@ int retro_vfs_file_error_impl(libretro_vfs_implementation_file *stream);
 
 int64_t retro_vfs_file_size_impl(libretro_vfs_implementation_file *stream);
 
+int retro_vfs_file_truncate_impl(libretro_vfs_implementation_file *stream, int64_t length);
+
 int64_t retro_vfs_file_tell_impl(libretro_vfs_implementation_file *stream);
 
 int64_t retro_vfs_file_seek_impl(libretro_vfs_implementation_file *stream, int64_t offset, int seek_position);

--- a/desmume/src/libretro-common/streams/file_stream.c
+++ b/desmume/src/libretro-common/streams/file_stream.c
@@ -40,6 +40,7 @@ static retro_vfs_get_path_t filestream_get_path_cb = NULL;
 static retro_vfs_open_t filestream_open_cb         = NULL;
 static retro_vfs_close_t filestream_close_cb       = NULL;
 static retro_vfs_size_t filestream_size_cb         = NULL;
+static retro_vfs_truncate_t filestream_truncate_cb = NULL;
 static retro_vfs_tell_t filestream_tell_cb         = NULL;
 static retro_vfs_seek_t filestream_seek_cb         = NULL;
 static retro_vfs_read_t filestream_read_cb         = NULL;
@@ -66,6 +67,7 @@ void filestream_vfs_init(const struct retro_vfs_interface_info* vfs_info)
    filestream_close_cb    = NULL;
    filestream_tell_cb     = NULL;
    filestream_size_cb     = NULL;
+   filestream_truncate_cb = NULL;
    filestream_seek_cb     = NULL;
    filestream_read_cb     = NULL;
    filestream_write_cb    = NULL;
@@ -83,6 +85,7 @@ void filestream_vfs_init(const struct retro_vfs_interface_info* vfs_info)
    filestream_open_cb     = vfs_iface->open;
    filestream_close_cb    = vfs_iface->close;
    filestream_size_cb     = vfs_iface->size;
+   filestream_truncate_cb = vfs_iface->truncate;
    filestream_tell_cb     = vfs_iface->tell;
    filestream_seek_cb     = vfs_iface->seek;
    filestream_read_cb     = vfs_iface->read;
@@ -119,6 +122,21 @@ int64_t filestream_get_size(RFILE *stream)
       output = filestream_size_cb(stream->hfile);
    else
       output = retro_vfs_file_size_impl((libretro_vfs_implementation_file*)stream->hfile);
+
+   if (output == vfs_error_return_value)
+      stream->error_flag = true;
+
+   return output;
+}
+
+int filestream_truncate(RFILE *stream, int64_t length)
+{
+   int64_t output;
+
+   if (filestream_truncate_cb != NULL)
+      output = filestream_truncate_cb(stream->hfile, length);
+   else
+      output = retro_vfs_file_truncate_impl((libretro_vfs_implementation_file*)stream->hfile, length);
 
    if (output == vfs_error_return_value)
       stream->error_flag = true;

--- a/desmume/src/libretro-common/streams/file_stream_transforms.c
+++ b/desmume/src/libretro-common/streams/file_stream_transforms.c
@@ -123,6 +123,11 @@ int rfputc(int character, RFILE * stream)
     return filestream_putc(stream, character);
 }
 
+int rfflush(RFILE * stream)
+{
+    return filestream_flush(stream);
+}
+
 int rfprintf(RFILE * stream, const char * format, ...)
 {
    int result;

--- a/desmume/src/libretro-common/vfs/vfs_implementation.c
+++ b/desmume/src/libretro-common/vfs/vfs_implementation.c
@@ -380,6 +380,22 @@ int64_t retro_vfs_file_size_impl(libretro_vfs_implementation_file *stream)
    return stream->size;
 }
 
+int retro_vfs_file_truncate_impl(libretro_vfs_implementation_file *stream, int64_t length)
+{
+   if (!stream)
+      return -1;
+
+#ifdef _WIN32
+   if(_chsize(_fileno(stream->fp), length) != 0)
+      return -1;
+#else
+   if(ftruncate(fileno(stream->fp), length) != 0)
+      return -1;
+#endif
+
+   return 0;
+}
+
 int64_t retro_vfs_file_tell_impl(libretro_vfs_implementation_file *stream)
 {
    if (!stream)

--- a/desmume/src/lua-engine.cpp
+++ b/desmume/src/lua-engine.cpp
@@ -57,7 +57,7 @@
 #include "saves.h"
 #include "emufile.h"
 
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 using namespace std;
 

--- a/desmume/src/lua-engine.cpp
+++ b/desmume/src/lua-engine.cpp
@@ -645,7 +645,7 @@ DEFINE_LUA_FUNCTION(emu_persistglobalvariables, "variabletable")
 	LuaSaveData exitData;
 	{
 		*pathTypeChrPtr = 'e';
-		FILE* persistFile = fopen_utf8(path, "rb");
+		FILE* persistFile = fopen(path, "rb");
 		if(persistFile)
 		{
 			exitData.ImportRecords(persistFile);
@@ -657,7 +657,7 @@ DEFINE_LUA_FUNCTION(emu_persistglobalvariables, "variabletable")
 	LuaSaveData defaultData;
 	{
 		*pathTypeChrPtr = 'd';
-		FILE* defaultsFile = fopen_utf8(path, "rb");
+		FILE* defaultsFile = fopen(path, "rb");
 		if(defaultsFile)
 		{
 			defaultData.ImportRecords(defaultsFile);
@@ -2199,7 +2199,7 @@ DEFINE_LUA_FUNCTION(state_loadscriptdata, "location")
 			//	strncpy(luaSaveFilename, Name, 512);
 			//	luaSaveFilename[512-(1+7/*strlen(".luasav")*/)] = '\0';
 			//	strcat(luaSaveFilename, ".luasav");
-			//	FILE* luaSaveFile = fopen_utf8(luaSaveFilename, "rb");
+			//	FILE* luaSaveFile = fopen(luaSaveFilename, "rb");
 			//	if(luaSaveFile)
 			//	{
 			//		saveData.ImportRecords(luaSaveFile);
@@ -5412,7 +5412,7 @@ void CallExitFunction(int uid)
 			*pathTypeChrPtr = 'd';
 			if(info.newDefaultData.recordList)
 			{
-				FILE* defaultsFile = fopen_utf8(path, "wb");
+				FILE* defaultsFile = fopen(path, "wb");
 				if(defaultsFile)
 				{
 					info.newDefaultData.ExportRecords(defaultsFile);
@@ -5424,7 +5424,7 @@ void CallExitFunction(int uid)
 			*pathTypeChrPtr = 'e';
 			if(newExitData.recordList)
 			{
-				FILE* persistFile = fopen_utf8(path, "wb");
+				FILE* persistFile = fopen(path, "wb");
 				if(persistFile)
 				{
 					newExitData.ExportRecords(persistFile);

--- a/desmume/src/mc.cpp
+++ b/desmume/src/mc.cpp
@@ -34,6 +34,8 @@
 #include "utils/xstring.h"
 #include "emufile.h"
 
+#include "streams/file_stream_transforms.h"
+
 //#define _DONT_SAVE_BACKUP
 //#define _MCLOG
 

--- a/desmume/src/mc.cpp
+++ b/desmume/src/mc.cpp
@@ -34,8 +34,6 @@
 #include "utils/xstring.h"
 #include "emufile.h"
 
-#include "streams/file_stream_transforms.h"
-
 //#define _DONT_SAVE_BACKUP
 //#define _MCLOG
 
@@ -237,7 +235,7 @@ BackupDevice::BackupDevice()
 
 	MCLOG("MC: %s\n", _fileName.c_str());
 
-	bool fexists = (access_utf8(_fileName.c_str(), 0) == 0)?true:false;
+	bool fexists = filestream_exists(_fileName.c_str());
 
 	if (fexists && CommonSettings.backupSave)
 	{

--- a/desmume/src/mc.cpp
+++ b/desmume/src/mc.cpp
@@ -1136,7 +1136,7 @@ const char no_GBA_HEADER_SRAM_ID[] = "SRAM";
 
 u32 BackupDevice::get_save_nogba_size(const char* fname)
 {
-	FILE *fsrc = (FILE*)fopen_utf8(fname, "rb");
+	FILE *fsrc = (FILE*)fopen(fname, "rb");
 	if (fsrc)
 	{
 		char src[0x50] = {0};
@@ -1297,7 +1297,7 @@ u32 BackupDevice::fillLeft(u32 size)
 
 bool BackupDevice::import_no_gba(const char *fname, u32 force_size)
 {
-	FILE	*fsrc = (FILE*)fopen_utf8(fname, "rb");
+	FILE	*fsrc = (FILE*)fopen(fname, "rb");
 	u8		*in_buf = NULL;
 	u8		*out_buf = NULL;
 
@@ -1374,7 +1374,7 @@ bool BackupDevice::export_no_gba(const char* fname)
 	fpMC->fread((char *)&data[0], fsize);
 	fpMC->fseek(pos, SEEK_SET);
 
-	FILE* outf = (FILE*)fopen_utf8(fname,"wb");
+	FILE* outf = (FILE*)fopen(fname,"wb");
 	if(!outf) return false;
 	u32 size = data.size();
 	u32 padSize = pad_up_size(size);
@@ -1403,7 +1403,7 @@ bool BackupDevice::export_raw(const char* filename)
 	fpMC->fread((char *)&data[0], fsize);
 	fpMC->fseek(pos, SEEK_SET);
 
-	FILE* outf = (FILE*)fopen_utf8(filename,"wb");
+	FILE* outf = (FILE*)fopen(filename,"wb");
 	if(!outf) return false;
 	u32 size = data.size();
 	u32 padSize = pad_up_size(size);
@@ -1459,7 +1459,7 @@ void BackupDevice::raw_applyUserSettings(u32& size, bool manual)
 
 u32 BackupDevice::get_save_raw_size(const char* fname)
 {
-	FILE* inf = (FILE*)fopen_utf8(fname,"rb");
+	FILE* inf = (FILE*)fopen(fname,"rb");
 	if (!inf) return 0xFFFFFFFF;
 
 	fseek(inf, 0, SEEK_END);
@@ -1470,7 +1470,7 @@ u32 BackupDevice::get_save_raw_size(const char* fname)
 
 bool BackupDevice::import_raw(const char* filename, u32 force_size)
 {
-	FILE* inf = (FILE*)fopen_utf8(filename,"rb");
+	FILE* inf = (FILE*)fopen(filename,"rb");
 
 	if (!inf) return false;
 
@@ -1510,7 +1510,7 @@ bool BackupDevice::import_raw(const char* filename, u32 force_size)
 
 u32 BackupDevice::get_save_duc_size(const char* fname)
 {
-	FILE* inf = (FILE*)fopen_utf8(fname,"rb");
+	FILE* inf = (FILE*)fopen(fname,"rb");
 	if (!inf) return 0xFFFFFFFF;
 
 	fseek(inf, 0, SEEK_END);
@@ -1524,7 +1524,7 @@ bool BackupDevice::import_duc(const char* filename, u32 force_size)
 {
 	u32 size;
 	u8 id16[16] = {0}, id4[4] = {0}, id3[3] = {0};
-	FILE* file = (FILE*)fopen_utf8(filename, "rb");
+	FILE* file = (FILE*)fopen(filename, "rb");
 
 	if(!file) return false;
 
@@ -1600,7 +1600,7 @@ bool BackupDevice::import_dsv(const char *filename)
 {
 	bool result = false;
 	
-	FILE *theFile = (FILE*)fopen_utf8(filename, "rb");
+	FILE *theFile = (FILE*)fopen(filename, "rb");
 	if (theFile == NULL)
 	{
 		return result;

--- a/desmume/src/mc.cpp
+++ b/desmume/src/mc.cpp
@@ -34,7 +34,7 @@
 #include "utils/xstring.h"
 #include "emufile.h"
 
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 //#define _DONT_SAVE_BACKUP
 //#define _MCLOG

--- a/desmume/src/mc.h
+++ b/desmume/src/mc.h
@@ -26,6 +26,8 @@
 
 #include "types.h"
 
+#include "streams/file_stream_transforms.h"
+
 #define MAX_SAVE_TYPES 13
 #define MC_TYPE_AUTODETECT      0x0
 #define MC_TYPE_EEPROM1         0x1

--- a/desmume/src/mc.h
+++ b/desmume/src/mc.h
@@ -26,7 +26,7 @@
 
 #include "types.h"
 
-#include "streams/file_stream_transforms.h"
+struct RFILE;
 
 #define MAX_SAVE_TYPES 13
 #define MC_TYPE_AUTODETECT      0x0
@@ -160,7 +160,7 @@ public:
 	BackupDeviceFileInfo GetFileInfo();
 
 	static size_t GetDSVFooterSize();
-	static bool GetDSVFileInfo(FILE *inFileDSV, BackupDeviceFileSaveFooter *outFooter, size_t *outFileSize);
+	static bool GetDSVFileInfo(struct RFILE *inFileDSV, BackupDeviceFileSaveFooter *outFooter, size_t *outFileSize);
 
 	//the value contained in memory when shipped from factory (before user program ever writes to it). more details commented elsewhere.
 	u8 uninitializedValue;

--- a/desmume/src/movie.cpp
+++ b/desmume/src/movie.cpp
@@ -29,8 +29,6 @@
 #include "utils/datetime.h"
 #include "encodings/utf.h"
 
-#include "streams/file_stream_transforms.h"
-
 #include "MMU.h"
 #include "NDSSystem.h"
 #include "readwrite.h"

--- a/desmume/src/movie.cpp
+++ b/desmume/src/movie.cpp
@@ -516,7 +516,7 @@ const char* _CDECL_ FCEUI_LoadMovie(const char *fname, bool _read_only, bool tas
 	currMovieData = MovieData();
 	
 	strcpy(curMovieFilename, fname);
-	//FCEUFILE *fp = FCEU_fopen_utf8(fname,0,"rb",0);
+	//FCEUFILE *fp = FCEU_fopen(fname,0,"rb",0);
 	//if (!fp) return;
 	//if(fp->isArchive() && !_read_only) {
 	//	FCEU_PrintError("Cannot open a movie in read+write from an archive.");
@@ -619,7 +619,7 @@ bool MovieData::loadSramFrom(std::vector<u8>* buf)
 ///*	memorystream ms;
 //
 //	//size it
-//	FILE * fp = (FILE*)fopen_utf8( fname.c_str(), "r" );
+//	FILE * fp = (FILE*)fopen( fname.c_str(), "r" );
 //	if(!fp)
 //		return 0;
 //	
@@ -1128,7 +1128,7 @@ static bool CheckFileExists(const char* filename)
 		checkFilename = filename;
 			
 	//Check if this filename exists
-	FILE* fp = (FILE*)fopen_utf8(checkFilename.c_str(), "rb");
+	FILE* fp = (FILE*)fopen(checkFilename.c_str(), "rb");
 		
 	if (!fp)
 	{

--- a/desmume/src/movie.cpp
+++ b/desmume/src/movie.cpp
@@ -29,7 +29,7 @@
 #include "utils/datetime.h"
 #include "encodings/utf.h"
 
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 #include "MMU.h"
 #include "NDSSystem.h"

--- a/desmume/src/saves.cpp
+++ b/desmume/src/saves.cpp
@@ -61,7 +61,7 @@
 #include "frontend/windows/main.h"
 #endif
 
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 int lastSaveState = 0;		//Keeps track of last savestate used for quick save/load functions
 

--- a/desmume/src/saves.cpp
+++ b/desmume/src/saves.cpp
@@ -680,10 +680,15 @@ void scan_savestates()
 	  
 	  if (strlen(filename) + strlen(".dst") + strlen("-2147483648") /* = biggest string for i */ >MAX_PATH) return ;
       sprintf(filename+strlen(filename), ".ds%d", i);
+#ifndef __LIBRETRO__
       if( stat_utf8(filename,&sbuf) == -1 ) continue;
-      savestates[i].exists = TRUE;
-      strncpy(savestates[i].date, format_time(sbuf.st_mtime),40);
+	  strncpy(savestates[i].date, format_time(sbuf.st_mtime),40);
 	  savestates[i].date[40-1] = '\0';
+#else
+      if( filestream_exists(filename) == false ) continue;
+	  savestates[i].date[0] = '\0';
+#endif
+      savestates[i].exists = TRUE;
     }
 
   return ;
@@ -715,12 +720,20 @@ void savestate_slot(int num)
 
    if (num >= 0 && num < NB_STATES)
    {
-          if (stat_utf8(filename,&sbuf) != -1)
+#ifndef __LIBRETRO__
+       if (stat_utf8(filename,&sbuf) != -1)
 	   {
 		   savestates[num].exists = TRUE;
 		   strncpy(savestates[num].date, format_time(sbuf.st_mtime),40);
 		   savestates[num].date[40-1] = '\0';
 	   }
+#else
+       if (filestream_exists(filename) == true)
+	   {
+		   savestates[num].exists = TRUE;
+		   savestates[num].date[0] = '\0';
+	   }
+#endif
    }
 }
 

--- a/desmume/src/saves.cpp
+++ b/desmume/src/saves.cpp
@@ -1058,7 +1058,7 @@ bool savestate_save (const char *file_name)
 	if (!savestate_save(ms, 0))
 #endif
 		return false;
-	FILE* file = (FILE*)fopen_utf8(file_name,"wb");
+	FILE* file = (FILE*)fopen(file_name,"wb");
 	if(file)
 	{
 		elems_written = fwrite(ms.buf(),1,ms.size(),file);

--- a/desmume/src/saves.cpp
+++ b/desmume/src/saves.cpp
@@ -61,7 +61,7 @@
 #include "frontend/windows/main.h"
 #endif
 
-#include "streams/file_stream_transforms.h"
+#include "streams/file_stream.h"
 
 int lastSaveState = 0;		//Keeps track of last savestate used for quick save/load functions
 

--- a/desmume/src/utils/AsmJit/core/memorymanager.cpp
+++ b/desmume/src/utils/AsmJit/core/memorymanager.cpp
@@ -1163,7 +1163,7 @@ GraphVizContext::~GraphVizContext()
 
 bool GraphVizContext::openFile(const char* fileName)
 {
-  file = (FILE*)fopen_utf8(fileName, "w");
+  file = (FILE*)fopen(fileName, "w");
   return file != NULL;
 }
 

--- a/desmume/src/utils/AsmJit/core/memorymanager.cpp
+++ b/desmume/src/utils/AsmJit/core/memorymanager.cpp
@@ -11,7 +11,7 @@
 #include "../core/lock.h"
 #include "../core/memorymanager.h"
 #include "../core/virtualmemory.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 // [Api-Begin]
 #include "../core/apibegin.h"

--- a/desmume/src/utils/advanscene.cpp
+++ b/desmume/src/utils/advanscene.cpp
@@ -25,7 +25,7 @@
 #include "../common.h"
 #include "../mc.h"
 #include "../emufile.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 ADVANsCEne advsc;
 

--- a/desmume/src/utils/advanscene.cpp
+++ b/desmume/src/utils/advanscene.cpp
@@ -25,6 +25,8 @@
 #include "../common.h"
 #include "../mc.h"
 #include "../emufile.h"
+
+#define SKIP_STDIO_REDEFINES
 #include "streams/file_stream_transforms.h"
 
 ADVANsCEne advsc;
@@ -37,7 +39,7 @@ ADVANsCEne advsc;
 u8 ADVANsCEne::checkDB(const char *ROMserial, u32 crc)
 {
 	loaded = false;
-	FILE *fp = (FILE*)rfopen(database_path.c_str(), "rb");
+	RFILE *fp = rfopen(database_path.c_str(), "rb");
 	if (fp)
 	{
 		char buf[64];

--- a/desmume/src/utils/advanscene.cpp
+++ b/desmume/src/utils/advanscene.cpp
@@ -37,7 +37,7 @@ ADVANsCEne advsc;
 u8 ADVANsCEne::checkDB(const char *ROMserial, u32 crc)
 {
 	loaded = false;
-	FILE *fp = (FILE*)fopen_utf8(database_path.c_str(), "rb");
+	FILE *fp = (FILE*)fopen(database_path.c_str(), "rb");
 	if (fp)
 	{
 		char buf[64];

--- a/desmume/src/utils/advanscene.cpp
+++ b/desmume/src/utils/advanscene.cpp
@@ -37,29 +37,29 @@ ADVANsCEne advsc;
 u8 ADVANsCEne::checkDB(const char *ROMserial, u32 crc)
 {
 	loaded = false;
-	FILE *fp = (FILE*)fopen(database_path.c_str(), "rb");
+	FILE *fp = (FILE*)rfopen(database_path.c_str(), "rb");
 	if (fp)
 	{
 		char buf[64];
 		memset(buf, 0, sizeof(buf));
-		if (fread(buf, 1, strlen(_ADVANsCEne_BASE_ID), fp) == strlen(_ADVANsCEne_BASE_ID))
+		if (rfread(buf, 1, strlen(_ADVANsCEne_BASE_ID), fp) == strlen(_ADVANsCEne_BASE_ID))
 		{
 			//printf("ID: %s\n", buf);
 			if (strcmp(buf, _ADVANsCEne_BASE_ID) == 0)
 			{
-				if (fread(&versionBase[0], 1, 2, fp) == 2)
+				if (rfread(&versionBase[0], 1, 2, fp) == 2)
 				{
 					//printf("Version base: %i.%i\n", versionBase[0], versionBase[1]);
-					if (fread(&version[0], 1, 4, fp) == 4)
+					if (rfread(&version[0], 1, 4, fp) == 4)
 					{
 						//printf("Version: %c%c%c%c\n", version[3], version[2], version[1], version[0]);
-						if (fread(&createTime, 1, sizeof(time_t), fp) == sizeof(time_t))
+						if (rfread(&createTime, 1, sizeof(time_t), fp) == sizeof(time_t))
 						{
 							memset(buf, 0,sizeof(buf));
 							// serial(8) + crc32(4) + save_type(1) = 13 + reserved(8) = 21
 							while (true)
 							{
-								if (fread(buf, 1, 21, fp) != 21) break;
+								if (rfread(buf, 1, 21, fp) != 21) break;
 
 								bool serialFound = (memcmp(&buf[4], ROMserial, 4) == 0);
 								u32 dbcrc = LE_TO_LOCAL_32(*(u32*)(buf+8));
@@ -73,7 +73,7 @@ u8 ADVANsCEne::checkDB(const char *ROMserial, u32 crc)
 									memcpy(&serial[0], &buf[4], 4);
 									//printf("%s founded: crc32=%04X, save type %02X\n", ROMserial, crc32, buf[12]);
 									saveType = buf[12];
-									fclose(fp);
+									rfclose(fp);
 									loaded = true;
 									return true;
 								}
@@ -83,7 +83,7 @@ u8 ADVANsCEne::checkDB(const char *ROMserial, u32 crc)
 				}
 			}
 		}
-		fclose(fp);
+		rfclose(fp);
 	}
 	return false;
 }

--- a/desmume/src/utils/dlditool.cpp
+++ b/desmume/src/utils/dlditool.cpp
@@ -70,7 +70,7 @@ typedef int int32_t;
 #endif
 
 #include <sys/stat.h>
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 namespace DLDI
 {

--- a/desmume/src/utils/dlditool.cpp
+++ b/desmume/src/utils/dlditool.cpp
@@ -222,7 +222,7 @@ FILE *openDLDIFile(const char *argv0, char *dldiFileName ) {
 
 	printf ("Trying \"%s\"\n", dldiFileName);
 	// try opening from current directory
-	dldiFile = (FILE*)fopen_utf8(dldiFileName,"rb");
+	dldiFile = (FILE*)fopen(dldiFileName,"rb");
 
 	if ( NULL != dldiFile ) return dldiFile;
 
@@ -243,7 +243,7 @@ FILE *openDLDIFile(const char *argv0, char *dldiFileName ) {
 		strcat ( appPath, dldiFileName );
 		
 		printf ("Trying \"%s\"\n", appPath);
-		dldiFile = (FILE*)fopen_utf8(appPath,"rb");
+		dldiFile = (FILE*)fopen(appPath,"rb");
 
 		if ( NULL != dldiFile ) return dldiFile;
 		 
@@ -304,7 +304,7 @@ FILE *openDLDIFile(const char *argv0, char *dldiFileName ) {
 	strcat(appPath,dldiFileName);	// add dldi filename to path
 	printf ("Trying \"%s\"\n", appPath);
 
-	return (FILE*)fopen_utf8(appPath,"rb");		// no more places to check, just return this handle
+	return (FILE*)fopen(appPath,"rb");		// no more places to check, just return this handle
 }
 #endif
 
@@ -368,7 +368,7 @@ FILE *openDLDIFile(const char *argv0, char *dldiFileName ) {
 //			return EXIT_FAILURE;
 //	}
 //
-//	if (!(appFile = (FILE*)fopen_utf8 (appFileName, "rb+"))) {
+//	if (!(appFile = (FILE*)fopen(appFileName, "rb+"))) {
 //		printf ("Cannot open \"%s\" - %s\n", appFileName, strerror(errno));
 //		return EXIT_FAILURE;
 //	}

--- a/desmume/src/utils/fsnitro.cpp
+++ b/desmume/src/utils/fsnitro.cpp
@@ -298,7 +298,7 @@ bool FS_NITRO::rebuildFAT(u32 addr, u32 size, std::string pathData)
 		std::string path = pathData + getFullPathByFileID(i);
 		//printf("%04Xh - %s (%d)\n", i, path.c_str(), fat[i].size);
 		fat[i].file = false;
-		FILE *fp = (FILE*)fopen_utf8(path.c_str(), "rb");
+		FILE *fp = (FILE*)fopen(path.c_str(), "rb");
 		if (!fp) continue;
 		fseek(fp, 0, SEEK_END);
 		u32 size = ftell(fp);
@@ -482,7 +482,7 @@ bool FS_NITRO::extract(u16 id, std::string to)
 {
 	printf("Extract to %s\n", to.c_str());
 
-	FILE *fp = (FILE*)fopen_utf8(to.c_str(), "wb");
+	FILE *fp = (FILE*)fopen(to.c_str(), "wb");
 	if (fp)
 	{
 		u32 remain = fat[id].size;

--- a/desmume/src/utils/fsnitro.cpp
+++ b/desmume/src/utils/fsnitro.cpp
@@ -23,7 +23,7 @@
 #include "fsnitro.h"
 #include "file/file_path.h"
 #include "NDSSystem.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 FS_NITRO::FS_NITRO()
 {

--- a/desmume/src/utils/tinyxml/tinyxml.cpp
+++ b/desmume/src/utils/tinyxml/tinyxml.cpp
@@ -30,6 +30,7 @@ distribution.
 #endif
 
 #include "tinyxml.h"
+#include "streams/file_stream_transforms.h"
 
 bool TiXmlBase::condenseWhiteSpace = true;
 

--- a/desmume/src/utils/tinyxml/tinyxml.cpp
+++ b/desmume/src/utils/tinyxml/tinyxml.cpp
@@ -30,24 +30,13 @@ distribution.
 #endif
 
 #include "tinyxml.h"
-#include "streams/file_stream_transforms.h"
-
-FILE* TiXmlFOpen( const char* filename, const char* mode );
 
 bool TiXmlBase::condenseWhiteSpace = true;
 
 // Microsoft compiler security
 FILE* TiXmlFOpen( const char* filename, const char* mode )
 {
-	#if defined(_MSC_VER) && (_MSC_VER >= 1400 )
-		FILE* fp = 0;
-		errno_t err = fopen_s( &fp, filename, mode );
-		if ( !err && fp )
-			return fp;
-		return 0;
-	#else
-		return (FILE*)fopen( filename, mode );
-	#endif
+	return (FILE*)fopen( filename, mode );
 }
 
 void TiXmlBase::EncodeString( const TIXML_STRING& str, TIXML_STRING* outString )

--- a/desmume/src/utils/tinyxml/tinyxml.cpp
+++ b/desmume/src/utils/tinyxml/tinyxml.cpp
@@ -46,7 +46,7 @@ FILE* TiXmlFOpen( const char* filename, const char* mode )
 			return fp;
 		return 0;
 	#else
-		return (FILE*)fopen_utf8( filename, mode );
+		return (FILE*)fopen( filename, mode );
 	#endif
 }
 

--- a/desmume/src/utils/tinyxml/tinyxml.cpp
+++ b/desmume/src/utils/tinyxml/tinyxml.cpp
@@ -30,7 +30,7 @@ distribution.
 #endif
 
 #include "tinyxml.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 FILE* TiXmlFOpen( const char* filename, const char* mode );
 

--- a/desmume/src/utils/tinyxml/tinyxml.h
+++ b/desmume/src/utils/tinyxml/tinyxml.h
@@ -38,7 +38,7 @@ distribution.
 #include <string.h>
 #include <assert.h>
 
-#include "streams/file_stream_transforms.h"
+typedef struct RFILE RFILE;
 
 // Help out windows:
 #if defined( _DEBUG ) && !defined( DEBUG )
@@ -212,7 +212,7 @@ public:
 		
 		(For an unformatted stream, use the << operator.)
 	*/
-	virtual void Print( FILE* cfile, int depth ) const = 0;
+	virtual void Print( RFILE* cfile, int depth ) const = 0;
 
 	/**	The world does not agree on whether white space should be kept or
 		not. In order to make everyone happy, these global, static functions
@@ -869,10 +869,10 @@ public:
 	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding );
 
 	// Prints this Attribute to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const {
+	virtual void Print( RFILE* cfile, int depth ) const {
 		Print( cfile, depth, 0 );
 	}
-	void Print( FILE* cfile, int depth, TIXML_STRING* str ) const;
+	void Print( RFILE* cfile, int depth, TIXML_STRING* str ) const;
 
 	// [internal use]
 	// Set the document pointer so the attribute can report errors.
@@ -1125,7 +1125,7 @@ public:
 	/// Creates a new Element and returns it - the returned element is a copy.
 	virtual TiXmlNode* Clone() const;
 	// Print the Element to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( RFILE* cfile, int depth ) const;
 
 	/*	Attribtue parsing starts: next char past '<'
 						 returns: next char past '>'
@@ -1178,7 +1178,7 @@ public:
 	/// Returns a copy of this Comment.
 	virtual TiXmlNode* Clone() const;
 	// Write this Comment to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( RFILE* cfile, int depth ) const;
 
 	/*	Attribtue parsing starts: at the ! of the !--
 						 returns: next char past '>'
@@ -1239,7 +1239,7 @@ public:
 	TiXmlText& operator=( const TiXmlText& base )							 	{ base.CopyTo( this ); return *this; }
 
 	// Write this text object to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( RFILE* cfile, int depth ) const;
 
 	/// Queries whether this represents text using a CDATA section.
 	bool CDATA() const				{ return cdata; }
@@ -1317,8 +1317,8 @@ public:
 	/// Creates a copy of this Declaration and returns it.
 	virtual TiXmlNode* Clone() const;
 	// Print this declaration to a FILE stream.
-	virtual void Print( FILE* cfile, int depth, TIXML_STRING* str ) const;
-	virtual void Print( FILE* cfile, int depth ) const {
+	virtual void Print( RFILE* cfile, int depth, TIXML_STRING* str ) const;
+	virtual void Print( RFILE* cfile, int depth ) const {
 		Print( cfile, depth, 0 );
 	}
 
@@ -1365,7 +1365,7 @@ public:
 	/// Creates a copy of this Unknown and returns it.
 	virtual TiXmlNode* Clone() const;
 	// Print this Unknown to a FILE stream.
-	virtual void Print( FILE* cfile, int depth ) const;
+	virtual void Print( RFILE* cfile, int depth ) const;
 
 	virtual const char* Parse( const char* p, TiXmlParsingData* data, TiXmlEncoding encoding );
 
@@ -1426,9 +1426,9 @@ public:
 		will be interpreted as an XML file. TinyXML doesn't stream in XML from the current
 		file location. Streaming may be added in the future.
 	*/
-	bool LoadFile( FILE*, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING );
+	bool LoadFile( RFILE*, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING );
 	/// Save a file using the given FILE*. Returns true if successful.
-	bool SaveFile( FILE* ) const;
+	bool SaveFile( RFILE* ) const;
 
 	#ifdef TIXML_USE_STL
 	bool LoadFile( const std::string& filename, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING )			///< STL std::string version.
@@ -1529,7 +1529,7 @@ public:
 	//char* PrintToMemory() const; 
 
 	/// Print this Document to a FILE stream.
-	virtual void Print( FILE* cfile, int depth = 0 ) const;
+	virtual void Print( RFILE* cfile, int depth = 0 ) const;
 	// [internal use]
 	void SetError( int err, const char* errorLocation, TiXmlParsingData* prevData, TiXmlEncoding encoding );
 

--- a/desmume/src/utils/tinyxml/tinyxml.h
+++ b/desmume/src/utils/tinyxml/tinyxml.h
@@ -38,6 +38,8 @@ distribution.
 #include <string.h>
 #include <assert.h>
 
+#include "streams/file_stream_transforms.h"
+
 // Help out windows:
 #if defined( _DEBUG ) && !defined( DEBUG )
 #define DEBUG
@@ -1516,7 +1518,9 @@ public:
 											}
 
 	/** Write the document to standard out using formatted printing ("pretty print"). */
+#ifndef __LIBRETRO__
 	void Print() const						{ Print( stdout, 0 ); }
+#endif
 
 	/* Write the document to a string using formatted printing ("pretty print"). This
 		will allocate a character array (new char[]) and return it as a pointer. The

--- a/desmume/src/utils/vfat.cpp
+++ b/desmume/src/utils/vfat.cpp
@@ -140,7 +140,7 @@ static void DirectoryListCallback(RDIR* rdir, EListCallbackArg arg)
 
 		if(callbackType == eCallbackType_Build)
 		{
-			FILE* inf = (FILE*)fopen_utf8(path.c_str(),"rb");
+			FILE* inf = (FILE*)fopen(path.c_str(),"rb");
 			if(inf)
 			{
 				fseek(inf,0,SEEK_END);

--- a/desmume/src/utils/vfat.cpp
+++ b/desmume/src/utils/vfat.cpp
@@ -33,7 +33,7 @@
 #include "emufat.h"
 #include "vfat.h"
 #include "libfat/libfat_public_api.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 enum EListCallbackArg {
 	EListCallbackArg_Item, EListCallbackArg_Pop

--- a/desmume/src/wifi.cpp
+++ b/desmume/src/wifi.cpp
@@ -2199,7 +2199,7 @@ void SoftAP_SendPacket(u8 *packet, u32 len)
 	/*static int ctr=0;
 	char buf[100];
 	sprintf(buf,"wifi%04d.txt",ctr);
-	FILE* outf = fopen_utf8(buf,"wb");
+	FILE* outf = fopen(buf,"wb");
 	fwrite(packet,1,len,outf);
 	fclose(outf);
 	ctr++;*/

--- a/desmume/src/wifi.cpp
+++ b/desmume/src/wifi.cpp
@@ -46,7 +46,7 @@
 #include "NDSSystem.h"
 #include "debug.h"
 #include "registers.h"
-#include "compat/fopen_utf8.h"
+#include "streams/file_stream_transforms.h"
 
 #ifndef INVALID_SOCKET 	 
 	#define INVALID_SOCKET  (socket_t)-1 	 


### PR DESCRIPTION
Added VFS support to core.

A few points to note:
- It seems to me core needs file truncation to work (what for I have no idea - NDS roms should be read only), so I added the functionality (one call) to the VFS and bumped its version to 2. Added the function pointer at the end of the VFS interface struct so that it's backwards compatible with previous one. If I'm mistaken and core does not need file truncation to work with Retroarch/Libretro I'd be happy to get rid of the VFS changes
- Core seems to use stat to get last modification date for save states. I don't think this is surfaced in any way in Retroarch/libretro so I just set the date to zero when building for libretro. Better than trying to add stat too to the VFS I thought.

Tested against current Retroarch without VFS v2 support, which means fallback implementation (which is what RetroArch would end up using) should work.