### PR TITLE
Fix mingw cross compile and add missing Nintendo targets

### DIFF
--- a/desmume/src/frontend/libretro/Makefile.libretro
+++ b/desmume/src/frontend/libretro/Makefile.libretro
@@ -264,13 +264,45 @@ else ifeq ($(platform), xenon)
    CXXFLAGS += -D__LIBXENON__ -m32 -D__ppc__
    STATIC_LINKING = 1
 
+# CTR (3DS)
+else ifeq ($(platform), ctr)
+   TARGET := $(TARGET_NAME)_libretro_$(platform).a
+   CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
+   CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
+   AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
+   STATIC_LINKING = 1
+   CXXFLAGS += -D_3DS
+   CXXFLAGS += -DARM11
+   CXXFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard
+   CXXFLAGS += -Wall -mword-relocations
+   CXXFLAGS += -fomit-frame-pointer -ffast-math
+   CXXFLAGS += -I$(DEVKITPRO)/libctru/include
+
+# Nintendo Game Cube
+else ifeq ($(platform), ngc)
+   TARGET := $(TARGET_NAME)_libretro_$(platform).a
+   CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
+   CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
+   AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
+   CXXFLAGS += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float
+   STATIC_LINKING = 1
+
 # Nintendo Wii
 else ifeq ($(platform), wii)
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-   CFLAGS += -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__
+   CXXFLAGS += -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__
+   STATIC_LINKING = 1
+
+# Nintendo WiiU
+else ifeq ($(platform), wiiu)
+   TARGET := $(TARGET_NAME)_libretro_$(platform).a
+   CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
+   CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
+   AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
+   CXXFLAGS += -DGEKKO -DWIIU -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float
    STATIC_LINKING = 1
 
 # Android

--- a/desmume/src/frontend/libretro/Makefile.libretro
+++ b/desmume/src/frontend/libretro/Makefile.libretro
@@ -461,8 +461,8 @@ CXXFLAGS += -DWIN32
 # Windows
 else
    TARGET := $(TARGET_NAME)_libretro.dll
-   CC = gcc
-   CXX = g++
+   CC ?= gcc
+   CXX ?= g++
    CFLAGS += -DHAVE_OPENGL -fno-strict-aliasing
    CXXFLAGS += -DHAVE_OPENGL -fno-strict-aliasing
    LIBS += -lopengl32

--- a/desmume/src/utils/AsmJit/core/build.h
+++ b/desmume/src/utils/AsmJit/core/build.h
@@ -282,7 +282,7 @@ static inline T asmjit_cast(Z* p) { return (T)p; }
 // ============================================================================
 
 #if defined(ASMJIT_WINDOWS)
-#include <Windows.h>
+#include <windows.h>
 #endif // ASMJIT_WINDOWS
 
 #if defined(__APPLE__)

--- a/desmume/src/wifi.cpp
+++ b/desmume/src/wifi.cpp
@@ -69,7 +69,7 @@
 
 #if defined(_WIN32) && defined(__LIBRETRO__)
 #include "frontend/windows/winpcap/pcap.h"
-#elif defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID)
+#elif defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS)
 typedef void* pcap_pkthdr;
 #else
 #include <pcap.h>
@@ -3098,7 +3098,7 @@ static const u8 SoftAP_DeauthFrame[] = {
 
 static void SoftAP_RXPacketGet_Callback(u_char *userData, const pcap_pkthdr *pktHeader, const u_char *pktData)
 {
-#if defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID)
+#if defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS)
 	return;
 #else
 	const WIFI_IOREG_MAP &io = wifiHandler->GetWifiData().io;
@@ -3558,7 +3558,7 @@ void* SoftAPCommInterface::_GetBridgeDeviceAtIndex(int deviceIndex, char *outErr
 	void *deviceList = NULL;
 	void *theDevice = NULL;
 
-#if defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID)
+#if defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS)
 	return theDevice;
 #else
 	int result = this->_pcap->findalldevs((void **)&deviceList, outErrorBuf);
@@ -4499,7 +4499,7 @@ int WifiHandler::GetBridgeDeviceList(std::vector<std::string> *deviceStringList)
 		return result;
 	}
 
-#if defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID)
+#if defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS)
 	return result;
 #else
 	char errbuf[PCAP_ERRBUF_SIZE];


### PR DESCRIPTION
Note the nintendo targets still don't compile due to inet.h references, but this brings the makefiles more in line with other cores.

Mingw x86 also fails to compile due to linker errors I haven't been able to figure out. x86_64 is fine, though.