### PR TITLE
Fix Emscripten build

### DIFF
--- a/desmume/src/ROMReader.cpp
+++ b/desmume/src/ROMReader.cpp
@@ -80,7 +80,7 @@ struct STDROMReaderData
 
 void* STDROMReaderInit(const char* filename)
 {
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && !defined(__EMSCRIPTEN__)
 	struct stat sb;
 	if (stat(filename, &sb) == -1)
 		return 0;

--- a/desmume/src/wifi.cpp
+++ b/desmume/src/wifi.cpp
@@ -69,7 +69,8 @@
 
 #if defined(_WIN32) && defined(__LIBRETRO__)
 #include "frontend/windows/winpcap/pcap.h"
-#elif defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS)
+#elif defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS) || defined(__EMSCRIPTEN__)
+#define NO_PCAP
 typedef void* pcap_pkthdr;
 #else
 #include <pcap/pcap.h>
@@ -3098,7 +3099,7 @@ static const u8 SoftAP_DeauthFrame[] = {
 
 static void SoftAP_RXPacketGet_Callback(u_char *userData, const pcap_pkthdr *pktHeader, const u_char *pktData)
 {
-#if defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS)
+#if defined(NO_PCAP)
 	return;
 #else
 	const WIFI_IOREG_MAP &io = wifiHandler->GetWifiData().io;
@@ -3558,7 +3559,7 @@ void* SoftAPCommInterface::_GetBridgeDeviceAtIndex(int deviceIndex, char *outErr
 	void *deviceList = NULL;
 	void *theDevice = NULL;
 
-#if defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS)
+#if defined(NO_PCAP)
 	return theDevice;
 #else
 	int result = this->_pcap->findalldevs((void **)&deviceList, outErrorBuf);
@@ -4499,7 +4500,7 @@ int WifiHandler::GetBridgeDeviceList(std::vector<std::string> *deviceStringList)
 		return result;
 	}
 
-#if defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS)
+#if defined(NO_PCAP)
 	return result;
 #else
 	char errbuf[PCAP_ERRBUF_SIZE];


### PR DESCRIPTION
That's all it took to fix the Emscripten build:
* Disable libpcap the same way it is disabled on other platforms that don't support it.
* Skip `stat` calls which look to be the only ones not going through the frontend's virtual filesystem.

This is experimentally being used at the moment in the [upcoming version of Junie](https://github.com/Namaneo/Junie/tree/emscripten).