### PR TITLE
Check for database before running crc32

### DIFF
--- a/desmume/src/NDSSystem.cpp
+++ b/desmume/src/NDSSystem.cpp
@@ -696,13 +696,15 @@ int NDS_LoadROM(const char *filename, const char *physicalName, const char *logi
 	gameInfo.populate();
 	
 	//run crc over the whole buffer (chunk at a time, to avoid coding a streaming crc
-	gameInfo.reader->Seek(gameInfo.fROM, 0, SEEK_SET);
-	gameInfo.crc = 0;
-	for(;;) {
-		u8 buf[4096];
-		int read = gameInfo.reader->Read(gameInfo.fROM,buf,4096);
-		if(read == 0) break;
-		gameInfo.crc = crc32(gameInfo.crc, buf, read);
+	if (advsc.hasDatabase()) {
+		gameInfo.reader->Seek(gameInfo.fROM, 0, SEEK_SET);
+		gameInfo.crc = 0;
+		for(;;) {
+			u8 buf[4096];
+			int read = gameInfo.reader->Read(gameInfo.fROM,buf,4096);
+			if(read == 0) break;
+			gameInfo.crc = crc32(gameInfo.crc, buf, read);
+		}
 	}
 
 	gameInfo.chipID  = 0xC2;														// The Manufacturer ID is defined by JEDEC (C2h = Macronix)

--- a/desmume/src/utils/advanscene.cpp
+++ b/desmume/src/utils/advanscene.cpp
@@ -99,6 +99,18 @@ void ADVANsCEne::setDatabase(const char *path)
 	loaded = false;
 }
 
+bool ADVANsCEne::hasDatabase()
+{
+	RFILE *fp = rfopen(database_path.c_str(), "rb");
+
+	if (fp) {
+		rfclose(fp);
+		return true;
+	}
+
+	return false;
+}
+
 bool ADVANsCEne::getXMLConfig(const char *in_filename)
 {
 	TiXmlDocument	*xml = NULL;

--- a/desmume/src/utils/advanscene.h
+++ b/desmume/src/utils/advanscene.h
@@ -53,6 +53,7 @@ public:
 		memset(serial, 0, sizeof(serial));
 	}
 	void setDatabase(const char *path);
+	bool hasDatabase();
 	std::string getDatabase() const { return database_path; }
 	u32 convertDB(const char *in_filename, EMUFILE &output);
 	u8 checkDB(const char *ROMserial, u32 crc);


### PR DESCRIPTION
This greatly improve startup time on systems where filesystem operations can be long and tedious (e.g. emscripten).