### PR TITLE
Fix typo in desmume_gfx_highres_interpolate_color description

### DIFF
--- a/desmume/src/frontend/libretro/libretro_core_options.h
+++ b/desmume/src/frontend/libretro/libretro_core_options.h
@@ -465,7 +465,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         "desmume_gfx_highres_interpolate_color",
         "Soft3D: High-res Color Interpolation",
         NULL,
-        "Enables High-res Color Inperpolation.",
+        "Enables High-res Color Interpolation.",
         NULL,
         "video",
         {


### PR DESCRIPTION
Super trivial fix: In**p**erpolation -->  In**t**erpolation

Screenshot of typo:

![Screenshot of typo](https://github.com/libretro/desmume/assets/466941/fde7ed1f-93a0-44ab-93cf-c50cfb4e998d)