### PR TITLE
libretro: do not use libpcap on webOS

### DIFF
--- a/desmume/src/frontend/libretro/Makefile.libretro
+++ b/desmume/src/frontend/libretro/Makefile.libretro
@@ -76,8 +76,8 @@ ifneq (,$(findstring unix,$(platform)))
       endif
    else
       ifneq (,$(findstring webos,$(CROSS_COMPILE)))
-         LIBS := -lpthread -lGLESv2 -lpcap
-         CXXFLAGS += -DHAVE_OPENGLES -std=gnu++11
+         LIBS := -lpthread -lGLESv2
+         CXXFLAGS += -DWEBOS -DHAVE_OPENGLES -std=gnu++11
          DESMUME_JIT_ARM = 1
          DESMUME_JIT = 0
       else

--- a/desmume/src/wifi.cpp
+++ b/desmume/src/wifi.cpp
@@ -69,7 +69,8 @@
 
 #if defined(_WIN32) && defined(__LIBRETRO__)
 #include "frontend/windows/winpcap/pcap.h"
-#elif defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS) || defined(__EMSCRIPTEN__)
+#elif defined(HAVE_LIBNX) || defined(__IOS__) || defined(ANDROID) || defined(GEKKO) || defined(_3DS) \
+|| defined(__EMSCRIPTEN__) || defined(WEBOS)
 #define NO_PCAP
 typedef void* pcap_pkthdr;
 #else


### PR DESCRIPTION
libpcap is not provided in the toolchain and it seems to be optional in the codebase!

Fixes building on webOS