### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,11 @@ include:
   # Linux 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
- 
+
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -83,6 +87,12 @@ libretro-build-windows-x64:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit

--- a/desmume/src/frontend/libretro/Makefile.libretro
+++ b/desmume/src/frontend/libretro/Makefile.libretro
@@ -120,6 +120,12 @@ ifneq (,$(findstring unix,$(platform)))
         HAVE_NEON = 1
       endif
       CXXFLAGS += -DARM
+   else ifneq (,$(filter aarch64 arm64,$(shell uname -m)))
+      # AArch64 (ARM64): no dynarec backend available (AsmJit is x86-only and the
+      # arm_arm JIT is 32-bit ARM only), so build the interpreter core.
+      ARCH = arm64
+      DESMUME_JIT = 0
+      DESMUME_JIT_ARM = 0
    else
       DESMUME_JIT ?= 1
    endif


### PR DESCRIPTION
## What

Adds a **Linux aarch64** libretro build to CI, matching the other cores that recently gained one.

Two parts:

1. **`Makefile.libretro`** — on a native `platform=unix` aarch64 build, fall back to the interpreter (`DESMUME_JIT=0`). The `unix` path previously did `DESMUME_JIT ?= 1`, which pulls in the **x86-only AsmJit** assembler (`utils/AsmJit/x86/…`); its `build.h` even `#define`s `ASMJIT_X86` as a fallback on non-x86, so on aarch64 it would (mis)build a 32-bit x86 code emitter. The 32-bit `arm_arm` JIT is ARMv7-only too, so aarch64 has no dynarec — exactly what `jni/Android.mk` already encodes for `arm64` (`JIT=0`).
2. **`.gitlab-ci.yml`** — add the `/linux-aarch64.yml` include + `libretro-build-linux-aarch64` job.

## Testing

Built the core for aarch64 (native gcc 15.2, `platform=unix`) — links cleanly, no AsmJit/JIT sources compiled. Ran the resulting `desmume_libretro.so` in RetroArch 1.22 on an aarch64 device and booted a retail NDS ROM to its title screen successfully (interpreter core, OpenGL renderer).