### PR TITLE
libretro: open content through the VFS, not stat()

### DIFF
--- a/desmume/src/ROMReader.cpp
+++ b/desmume/src/ROMReader.cpp
@@ -80,7 +80,12 @@ struct STDROMReaderData
 
 void* STDROMReaderInit(const char* filename)
 {
-#if !defined(_MSC_VER) && !defined(__EMSCRIPTEN__)
+#if defined(__LIBRETRO__)
+	/* stat() cannot see content the frontend hands us as a URI (Android SAF),
+	   so ask the VFS instead of the C library */
+	if (!filestream_exists(filename))
+		return 0;
+#elif !defined(_MSC_VER) && !defined(__EMSCRIPTEN__)
 	struct stat sb;
 	if (stat(filename, &sb) == -1)
 		return 0;


### PR DESCRIPTION
Fixes #125. On RetroArch Plus content arrives as a SAF URI, and `STDROMReaderInit()` gated the open behind `stat()`, which cannot resolve one. The gate failed, `Init()` returned NULL and every ROM was reported as failing to load — even though the `fopen()` right below it is already `rfopen()` through `file_stream_transforms.h` and would have gone to the frontend.

Under `__LIBRETRO__` the check now uses `filestream_exists()`, so it asks the same VFS that does the reading. Other frontends keep the `stat()` path, which also still rejects non-regular files there.

Tested with a small harness that loads the core and hands it a VFS whose paths are not real file paths (the way SAF URIs behave — `stat()`/`fopen()` on them fail, only the VFS callbacks can open them): before the change `retro_load_game()` returns false, after it the ROM loads and runs.